### PR TITLE
Missing for sale ship in BS Osiris St01 fix

### DIFF
--- a/DATA/UNIVERSE/SYSTEMS/St01/BASES/ROOMS/st01_02_deck.ini
+++ b/DATA/UNIVERSE/SYSTEMS/St01/BASES/ROOMS/st01_02_deck.ini
@@ -1,0 +1,93 @@
+[Room_Info]
+scene = all, ambient, Scripts\Bases\li_05_Deck_ambi_int_01.thn
+set_script = Scripts\Bases\Li_05_Deck_hardpoint_01.thn
+
+[Spiels]
+CommodityDealer = manhattan_commodity_spiel
+EquipmentDealer = manhattan_equipment_spiel
+
+[Room_Sound]
+ambient = ambience_deck_space_larger
+
+[CharacterPlacement]
+name = Zg/PC/Player/01/A/Stand
+
+[PlayerShipPlacement]
+name = X/Shipcentre/01
+
+[ForSaleShipPlacement]
+name = X/Shipcentre/02
+
+[Camera]
+name = Camera_0
+
+[Hotspot]
+name = IDS_HOTSPOT_DECK
+behavior = ExitDoor
+room_switch = Deck
+
+[Hotspot]
+name = IDS_HOTSPOT_BAR
+behavior = ExitDoor
+room_switch = Bar
+
+[Hotspot]
+name = IDS_HOTSPOT_EQUIPMENTDEALER_ROOM
+behavior = VirtualRoom
+room_switch = Equipment
+
+[Hotspot]
+name = IDS_HOTSPOT_SHIPDEALER_ROOM
+behavior = VirtualRoom
+room_switch = ShipDealer
+
+[Hotspot]
+name = IDS_NN_REPAIR_YOUR_SHIP
+behavior = Repair
+virtual_room = Deck
+
+[Hotspot]
+name = IDS_DEALER_FRONT_DESK
+behavior = FrontDesk
+state_read = 1
+state_send = 2
+virtual_room = Equipment
+
+[Hotspot]
+name = IDS_HOTSPOT_EQUIPMENTDEALER
+behavior = StartEquipDealer
+state_read = 2
+state_send = 1
+virtual_room = Equipment
+
+[Hotspot]
+name = IDS_EQUIPMENT_ROOM_RIGHT
+behavior = MoveRight
+state_read = 2
+state_send = 1
+virtual_room = Equipment
+
+[Hotspot]
+name = IDS_NN_REPAIR_YOUR_SHIP
+behavior = Repair
+virtual_room = Equipment
+
+[Hotspot]
+name = IDS_DEALER_FRONT_DESK
+behavior = FrontDesk
+state_read = 1
+state_send = 2
+virtual_room = ShipDealer
+
+[Hotspot]
+name = IDS_HOTSPOT_SHIPDEALER
+behavior = StartShipDealer
+state_read = 2
+state_send = 1
+virtual_room = ShipDealer
+
+[Hotspot]
+name = IDS_NN_REPAIR_YOUR_SHIP
+behavior = Repair
+virtual_room = ShipDealer
+


### PR DESCRIPTION
This PR simply adds the st01_02_deck.ini file from Freelancer: HD Edition. Apart from the `[ForSaleShipPlacement]` line entry, this file is completely vanilla.