### PR TITLE
15 check freeport shipdealer rooms and icons

### DIFF
--- a/DATA/UNIVERSE/SYSTEMS/Br05/Bases/Rooms/Br05_01_Deck2.ini
+++ b/DATA/UNIVERSE/SYSTEMS/Br05/Bases/Rooms/Br05_01_Deck2.ini
@@ -1,0 +1,26 @@
+[Room_Info]
+set_script = Scripts\Bases\br_04_Deck_HardPoint_01.thn
+scene = all, ambient, Scripts\Bases\br_04_Deck_ambi_int_01.thn
+
+[Room_Sound]
+ambient = ambience_deck_space_smaller
+
+[PlayerShipPlacement]
+name = X/Shipcentre/01
+
+[ForSaleShipPlacement]
+name = X/Shipcentre/02
+
+[Camera]
+name = Camera_0
+
+[Hotspot]
+name = IDS_HOTSPOT_DECK
+behavior = ExitDoor
+room_switch = Deck
+
+[Hotspot]
+name = IDS_HOTSPOT_BAR
+behavior = ExitDoor
+room_switch = Bar
+

--- a/DATA/UNIVERSE/SYSTEMS/Bw01/BASES/ROOMS/Bw01_02_Bar.ini
+++ b/DATA/UNIVERSE/SYSTEMS/Bw01/BASES/ROOMS/Bw01_02_Bar.ini
@@ -1,22 +1,15 @@
 [Room_Info]
-set_script = Scripts\Bases\br_07_deck_hardpoint_sdlr.thn
-scene = all, ambient, Scripts\Bases\br_04_Deck_ambi_int_01.thn
-animation = Sc_loop
-
-[Spiels]
-ShipDealer = manhattan_ship_spiel
+set_script = scripts\bases\cv_01_Bar_hardpoint_01.thn
+scene = ambient, scripts\bases\cv_01_bar_ambi_Bw01_02.thn
+scene = ambient, scripts\bases\Ambi_Terrain_Distant.thn
 
 [Room_Sound]
-ambient = ambience_deck_space_larger
+music = music_bar_generic01
+ambient = ambience_deck_space_smaller
 
 [CharacterPlacement]
 name = Zg/PC/Player/01/A/Stand
-
-[PlayerShipPlacement]
-name = X/Shipcentre/01
-
-[ForSaleShipPlacement]
-name = X/Shipcentre/02
+start_script = Scripts\Bases\cv_01_bar_enter_01.thn
 
 [Camera]
 name = Camera_0
@@ -49,17 +42,10 @@ behavior = ExitDoor
 room_switch = ShipDealer
 
 [Hotspot]
-name = IDS_DEALER_FRONT_DESK
-behavior = FrontDesk
-state_read = 1
-state_send = 2
+name = IDS_HOTSPOT_NEWSVENDOR
+behavior = NewsVendor
 
 [Hotspot]
-name = IDS_NN_REPAIR_YOUR_SHIP
-behavior = Repair
+name = IDS_HOTSPOT_MISSIONVENDOR
+behavior = MissionVendor
 
-[Hotspot]
-name = IDS_HOTSPOT_SHIPDEALER
-behavior = StartShipDealer
-state_read = 2
-state_send = 1

--- a/DATA/UNIVERSE/SYSTEMS/Bw09/BASES/ROOMS/Bw09_03_Bar.ini
+++ b/DATA/UNIVERSE/SYSTEMS/Bw09/BASES/ROOMS/Bw09_03_Bar.ini
@@ -1,0 +1,52 @@
+[Room_Info]
+set_script = scripts\bases\cv_01_Bar_hardpoint_01.thn
+scene = ambient, scripts\bases\cv_01_bar_ambi_Bw09_03.thn
+scene = ambient, scripts\bases\Ambi_Terrain_Static_D01.thn
+scene = ambient, scripts\bases\Ambi_Terrain_Static_D02.thn
+
+[Room_Sound]
+music = music_bar_generic04
+ambient = ambience_deck_space_smaller
+
+[CharacterPlacement]
+name = Zg/PC/Player/01/A/Stand
+start_script = Scripts\Bases\cv_01_bar_enter_01.thn
+
+[Camera]
+name = Camera_0
+
+[Hotspot]
+name = IDS_HOTSPOT_DECK
+behavior = ExitDoor
+room_switch = Deck
+
+[Hotspot]
+name = IDS_HOTSPOT_BAR
+behavior = ExitDoor
+room_switch = Bar
+
+[Hotspot]
+name = IDS_HOTSPOT_COMMODITYTRADER_ROOM
+behavior = ExitDoor
+room_switch = Deck
+set_virtual_room = Trader
+
+[Hotspot]
+name = IDS_HOTSPOT_EQUIPMENTDEALER_ROOM
+behavior = ExitDoor
+room_switch = Deck
+set_virtual_room = Equipment
+
+[Hotspot]
+name = IDS_HOTSPOT_SHIPDEALER_ROOM
+behavior = ExitDoor
+room_switch = ShipDealer
+
+[Hotspot]
+name = IDS_HOTSPOT_NEWSVENDOR
+behavior = NewsVendor
+
+[Hotspot]
+name = IDS_HOTSPOT_MISSIONVENDOR
+behavior = MissionVendor
+

--- a/DATA/UNIVERSE/SYSTEMS/Ew01/BASES/ROOMS/Ew01_01_Bar.ini
+++ b/DATA/UNIVERSE/SYSTEMS/Ew01/BASES/ROOMS/Ew01_01_Bar.ini
@@ -1,0 +1,52 @@
+[Room_Info]
+set_script = scripts\bases\cv_01_Bar_hardpoint_01.thn
+scene = ambient, scripts\bases\cv_01_bar_ambi_Ew01_01.thn
+scene = ambient, scripts\bases\Ambi_Terrain_Static_D01.thn
+scene = ambient, scripts\bases\Ambi_Terrain_Dynamic.thn
+
+[Room_Sound]
+music = music_bar_generic07
+ambient = ambience_deck_space_smaller
+
+[CharacterPlacement]
+name = Zg/PC/Player/01/A/Stand
+start_script = Scripts\Bases\cv_01_bar_enter_01.thn
+
+[Camera]
+name = Camera_0
+
+[Hotspot]
+name = IDS_HOTSPOT_DECK
+behavior = ExitDoor
+room_switch = Deck
+
+[Hotspot]
+name = IDS_HOTSPOT_BAR
+behavior = ExitDoor
+room_switch = Bar
+
+[Hotspot]
+name = IDS_HOTSPOT_COMMODITYTRADER_ROOM
+behavior = ExitDoor
+room_switch = Deck
+set_virtual_room = Trader
+
+[Hotspot]
+name = IDS_HOTSPOT_EQUIPMENTDEALER_ROOM
+behavior = ExitDoor
+room_switch = Deck
+set_virtual_room = Equipment
+
+[Hotspot]
+name = IDS_HOTSPOT_SHIPDEALER_ROOM
+behavior = ExitDoor
+room_switch = ShipDealer
+
+[Hotspot]
+name = IDS_HOTSPOT_NEWSVENDOR
+behavior = NewsVendor
+
+[Hotspot]
+name = IDS_HOTSPOT_MISSIONVENDOR
+behavior = MissionVendor
+

--- a/DATA/UNIVERSE/SYSTEMS/Ew03/BASES/ROOMS/Ew03_02_Bar.ini
+++ b/DATA/UNIVERSE/SYSTEMS/Ew03/BASES/ROOMS/Ew03_02_Bar.ini
@@ -1,0 +1,52 @@
+[Room_Info]
+set_script = scripts\bases\li_09_Bar_hardpoint_L5.thn
+scene = ambient, scripts\bases\li_09_bar_ambi_Ew03_02.thn
+scene = ambient, scripts\bases\Ambi_Terrain_Static_D01.thn
+scene = ambient, scripts\bases\Ambi_Terrain_Static_D02.thn
+
+[Room_Sound]
+music = music_bar_generic10
+ambient = ambience_deck_space_smaller
+
+[CharacterPlacement]
+name = Zg/PC/Player/01/A/Stand
+start_script = Scripts\Bases\li_09_bar_enter_01.thn
+
+[Camera]
+name = Camera_0
+
+[Hotspot]
+name = IDS_HOTSPOT_DECK
+behavior = ExitDoor
+room_switch = Deck
+
+[Hotspot]
+name = IDS_HOTSPOT_BAR
+behavior = ExitDoor
+room_switch = Bar
+
+[Hotspot]
+name = IDS_HOTSPOT_COMMODITYTRADER_ROOM
+behavior = ExitDoor
+room_switch = Deck
+set_virtual_room = Trader
+
+[Hotspot]
+name = IDS_HOTSPOT_EQUIPMENTDEALER_ROOM
+behavior = ExitDoor
+room_switch = Deck
+set_virtual_room = Equipment
+
+[Hotspot]
+name = IDS_HOTSPOT_SHIPDEALER_ROOM
+behavior = ExitDoor
+room_switch = ShipDealer
+
+[Hotspot]
+name = IDS_HOTSPOT_NEWSVENDOR
+behavior = NewsVendor
+
+[Hotspot]
+name = IDS_HOTSPOT_MISSIONVENDOR
+behavior = MissionVendor
+

--- a/DATA/UNIVERSE/SYSTEMS/Ew04/BASES/ROOMS/Ew04_01_Bar.ini
+++ b/DATA/UNIVERSE/SYSTEMS/Ew04/BASES/ROOMS/Ew04_01_Bar.ini
@@ -1,0 +1,50 @@
+[Room_Info]
+set_script = scripts\bases\cv_01_Bar_hardpoint_01.thn
+scene = ambient, scripts\bases\cv_01_bar_ambi_Ew04_01.thn
+
+[Room_Sound]
+music = music_bar_generic01
+ambient = ambience_deck_space_smaller
+
+[CharacterPlacement]
+name = Zg/PC/Player/01/A/Stand
+start_script = Scripts\Bases\cv_01_bar_enter_01.thn
+
+[Camera]
+name = Camera_0
+
+[Hotspot]
+name = IDS_HOTSPOT_DECK
+behavior = ExitDoor
+room_switch = Deck
+
+[Hotspot]
+name = IDS_HOTSPOT_BAR
+behavior = ExitDoor
+room_switch = Bar
+
+[Hotspot]
+name = IDS_HOTSPOT_COMMODITYTRADER_ROOM
+behavior = ExitDoor
+room_switch = Deck
+set_virtual_room = Trader
+
+[Hotspot]
+name = IDS_HOTSPOT_EQUIPMENTDEALER_ROOM
+behavior = ExitDoor
+room_switch = Deck
+set_virtual_room = Equipment
+
+[Hotspot]
+name = IDS_HOTSPOT_SHIPDEALER_ROOM
+behavior = ExitDoor
+room_switch = ShipDealer
+
+[Hotspot]
+name = IDS_HOTSPOT_NEWSVENDOR
+behavior = NewsVendor
+
+[Hotspot]
+name = IDS_HOTSPOT_MISSIONVENDOR
+behavior = MissionVendor
+

--- a/DATA/UNIVERSE/SYSTEMS/Iw01/BASES/ROOMS/Iw01_02_Bar.ini
+++ b/DATA/UNIVERSE/SYSTEMS/Iw01/BASES/ROOMS/Iw01_02_Bar.ini
@@ -1,0 +1,53 @@
+[Room_Info]
+set_script = scripts\bases\cv_01_Bar_hardpoint_01.thn
+scene = ambient, scripts\bases\cv_01_bar_ambi_Iw01_02.thn
+scene = ambient, scripts\bases\Ambi_Terrain_Static_D01.thn
+scene = ambient, scripts\bases\Ambi_Terrain_Dynamic.thn
+scene = ambient, scripts\bases\Ambi_Terrain_Distant.thn
+
+[Room_Sound]
+music = music_bar_generic06
+ambient = ambience_deck_space_smaller
+
+[CharacterPlacement]
+name = Zg/PC/Player/01/A/Stand
+start_script = Scripts\Bases\cv_01_bar_enter_01.thn
+
+[Camera]
+name = Camera_0
+
+[Hotspot]
+name = IDS_HOTSPOT_DECK
+behavior = ExitDoor
+room_switch = Deck
+
+[Hotspot]
+name = IDS_HOTSPOT_BAR
+behavior = ExitDoor
+room_switch = Bar
+
+[Hotspot]
+name = IDS_HOTSPOT_COMMODITYTRADER_ROOM
+behavior = ExitDoor
+room_switch = Deck
+set_virtual_room = Trader
+
+[Hotspot]
+name = IDS_HOTSPOT_EQUIPMENTDEALER_ROOM
+behavior = ExitDoor
+room_switch = Deck
+set_virtual_room = Equipment
+
+[Hotspot]
+name = IDS_HOTSPOT_SHIPDEALER_ROOM
+behavior = ExitDoor
+room_switch = ShipDealer
+
+[Hotspot]
+name = IDS_HOTSPOT_NEWSVENDOR
+behavior = NewsVendor
+
+[Hotspot]
+name = IDS_HOTSPOT_MISSIONVENDOR
+behavior = MissionVendor
+

--- a/DATA/UNIVERSE/SYSTEMS/Iw03/BASES/ROOMS/Iw03_01_Bar.ini
+++ b/DATA/UNIVERSE/SYSTEMS/Iw03/BASES/ROOMS/Iw03_01_Bar.ini
@@ -1,0 +1,50 @@
+[Room_Info]
+set_script = scripts\bases\cv_01_Bar_hardpoint_01.thn
+scene = ambient, scripts\bases\cv_01_bar_ambi_Iw03_01.thn
+
+[Room_Sound]
+music = music_bar_generic09
+ambient = ambience_deck_space_smaller
+
+[CharacterPlacement]
+name = Zg/PC/Player/01/A/Stand
+start_script = Scripts\Bases\cv_01_bar_enter_01.thn
+
+[Camera]
+name = Camera_0
+
+[Hotspot]
+name = IDS_HOTSPOT_DECK
+behavior = ExitDoor
+room_switch = Deck
+
+[Hotspot]
+name = IDS_HOTSPOT_BAR
+behavior = ExitDoor
+room_switch = Bar
+
+[Hotspot]
+name = IDS_HOTSPOT_COMMODITYTRADER_ROOM
+behavior = ExitDoor
+room_switch = Deck
+set_virtual_room = Trader
+
+[Hotspot]
+name = IDS_HOTSPOT_EQUIPMENTDEALER_ROOM
+behavior = ExitDoor
+room_switch = Deck
+set_virtual_room = Equipment
+
+[Hotspot]
+name = IDS_HOTSPOT_SHIPDEALER_ROOM
+behavior = ExitDoor
+room_switch = ShipDealer
+
+[Hotspot]
+name = IDS_HOTSPOT_NEWSVENDOR
+behavior = NewsVendor
+
+[Hotspot]
+name = IDS_HOTSPOT_MISSIONVENDOR
+behavior = MissionVendor
+


### PR DESCRIPTION
Corrected navigational issues with new ship dealers on Freeport bases -- all files were missing the ship dealer hotspot code block.

Corrected vanilla error with missing setpoint codeblock that was also found in the new Freeport 1 ship dealer.