### PR TITLE
Fixed shield module disabling shield impact effects

### DIFF
--- a/DATA/EQUIPMENT/shield_equip.ini
+++ b/DATA/EQUIPMENT/shield_equip.ini
@@ -7866,7 +7866,7 @@ ids_info = 460629
 ; 
 ; This Module will increase your Shields capacity by a lesser amount and needs a small amount of constant power.\n
 DA_archetype = equipment\models\st\no_thruster.3db
-HP_child = HpConnect
+HP_child = HpMount
 hit_pts = 0
 explosion_resistance = 0.5
 debris_type = debris_normal
@@ -7899,7 +7899,7 @@ ids_info = 460630
 ; 
 ; This advanced module will increase your Shields capacity by a high amount but also needs a constant power supply.\n
 DA_archetype = equipment\models\st\no_thruster.3db
-HP_child = HpConnect
+HP_child = HpMount
 hit_pts = 0
 explosion_resistance = 0.5
 debris_type = debris_normal
@@ -7932,7 +7932,7 @@ ids_info = 460631
 ; 
 ; This optimized module will increase your Shields capacity by a massively high amount but it also has a high demand for constant power supply.\n
 DA_archetype = equipment\models\st\no_thruster.3db
-HP_child = HpConnect
+HP_child = HpMount
 hit_pts = 0
 explosion_resistance = 0.5
 debris_type = debris_normal
@@ -7965,7 +7965,7 @@ ids_info = 460632
 ; 
 ; This Module will increase your Shields regeneration power by a lesser amount and needs a small amount of constant power.\n
 DA_archetype = equipment\models\st\no_thruster.3db
-HP_child = HpConnect
+HP_child = HpMount
 hit_pts = 0
 explosion_resistance = 0.5
 debris_type = debris_normal
@@ -7998,7 +7998,7 @@ ids_info = 460633
 ; 
 ; This advanced module will increase your Shields regeneration power by a high amountbut also needs a constant power supply.\n
 DA_archetype = equipment\models\st\no_thruster.3db
-HP_child = HpConnect
+HP_child = HpMount
 hit_pts = 0
 explosion_resistance = 0.5
 debris_type = debris_normal
@@ -8031,7 +8031,7 @@ ids_info = 460634
 ; 
 ; This optimized module will increase your Shields regeneration power by a massively high amountbut it also has a high demand for constant power supply.\n
 DA_archetype = equipment\models\st\no_thruster.3db
-HP_child = HpConnect
+HP_child = HpMount
 hit_pts = 0
 explosion_resistance = 0.5
 debris_type = debris_normal


### PR DESCRIPTION
By changing HP_child from HpConnect to HpMount it fixes this problem. Modules still function in an additive way.