### PR TITLE
Leeds tradelanes

### DIFF
--- a/DATA/UNIVERSE/SYSTEMS/Br04/Br04.ini
+++ b/DATA/UNIVERSE/SYSTEMS/Br04/Br04.ini
@@ -657,7 +657,7 @@ faction = co_ti_grp, 0.08
 [Object]
 nickname = Br04_Trade_Lane_Ring_8
 ids_name = 260679
-pos = 14521, 0, 30571
+pos = 13365, 0, 33121
 rotate = 0, -24, 0
 archetype = Trade_Lane_Ring
 next_ring = Br04_Trade_Lane_Ring_9
@@ -673,7 +673,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_9
 ids_name = 260679
-pos = 17618, 0, 23741
+pos = 16627, 0, 25926
 rotate = 0, -24, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_8
@@ -689,7 +689,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_10
 ids_name = 260679
-pos = 20715, 0, 16910
+pos = 19889, 0, 18731
 rotate = 0, -24, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_9
@@ -705,7 +705,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_11
 ids_name = 260679
-pos = 23812, 0, 10079
+pos = 23151, 0, 11536
 rotate = 0, -24, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_10
@@ -721,7 +721,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_12
 ids_name = 260679
-pos = 26908, 0, 3248
+pos = 26413, 0, 4341
 rotate = 0, -24, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_11
@@ -737,7 +737,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_13
 ids_name = 260679
-pos = 30005, 0, -3583
+pos = 29675, 0, -2854
 rotate = 0, -24, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_12
@@ -753,7 +753,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_14
 ids_name = 260679
-pos = 33102, 0, -10414
+pos = 32937, 0, -10049
 rotate = 0, -24, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_13
@@ -785,10 +785,10 @@ pilot = pilot_solar_ace
 
 [zone]
 nickname = Zone_Br04_Tradelane_2
-pos = 25360, 0, 6663
+pos = 24741, 0, 8029
 rotate = 0, -24, 0
 shape = BOX
-size = 800,54098
+size = 800, 1200, 57098
 comment = .                Tradelane to Stokes
 lane_id = br04_2
 tradelane_down = 10
@@ -1744,7 +1744,7 @@ nickname = Br04_02
 ids_name = 460017
 ;res str stokes
 ; Stokes Smelter
-pos = 37995, 0, -19398
+pos = 37695, 0, -18898
 archetype = space_factory01
 ids_info = 65681
 base = Br04_02_Base
@@ -1760,7 +1760,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_stokes_mplatform_1
 ids_name = 60213
-pos = 38487, -21, -19937
+pos = 38187, -21, -19437
 archetype = mplatform
 reputation = br_m_grp
 parent = Br04_02
@@ -1772,7 +1772,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_space_tankl4_2
 ids_name = 60251
-pos = 38489, 0, -18883
+pos = 38189, 0, -18383
 archetype = space_tankl4
 reputation = br_m_grp
 parent = Br04_02
@@ -1780,7 +1780,7 @@ parent = Br04_02
 [Object]
 nickname = Br04_space_tankl4x4_1
 ids_name = 60251
-pos = 38690, 0, -19397
+pos = 38390, 0, -18897
 rotate = 0, 90, 0
 archetype = space_tankl4x4
 reputation = br_m_grp
@@ -1789,7 +1789,7 @@ parent = Br04_02
 [Object]
 nickname = Br04_stokes_platform_2
 ids_name = 60213
-pos = 39025, -21, -18920
+pos = 38725, -21, -18420
 rotate = 0, 180, 0
 archetype = mplatform
 reputation = br_m_grp
@@ -4591,7 +4591,7 @@ faction = br_m_grp, 1
 
 [Object]
 nickname = Br04_space_industrial01_1
-pos = 39030, 0, -19151
+pos = 38730, 0, -18651
 rotate = 0, -90, 0
 archetype = space_industrial01
 reputation = br_m_grp

--- a/DATA/UNIVERSE/SYSTEMS/Br04/Br04.ini
+++ b/DATA/UNIVERSE/SYSTEMS/Br04/Br04.ini
@@ -511,7 +511,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_1
 ids_name = 260677
-pos = 11718, 0, 38023
+pos = 11224, 0, 40474
 rotate = 0, 169, 0
 archetype = Trade_Lane_Ring
 next_ring = Br04_Trade_Lane_Ring_2
@@ -527,7 +527,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_2
 ids_name = 260677
-pos = 10154, 0, 45784
+pos = 9743, 0, 47826
 rotate = 0, 169, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_1
@@ -543,7 +543,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_3
 ids_name = 260677
-pos = 8591, 0, 53545
+pos = 8261, 0, 55178
 rotate = 0, 169, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_2
@@ -559,7 +559,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_4
 ids_name = 260677
-pos = 7027, 0, 61306
+pos = 6780, 0, 62531
 rotate = 0, 169, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_3
@@ -575,7 +575,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_5
 ids_name = 260677
-pos = 5463, 0, 69067
+pos = 5299, 0, 69883
 rotate = 0, 169, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_4
@@ -591,7 +591,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_6
 ids_name = 260677
-pos = 3900, 0, 76827
+pos = 3818, 0, 77235
 rotate = 0, 169, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_5
@@ -622,10 +622,10 @@ pilot = pilot_solar_ace
 
 [zone]
 nickname = Zone_Br04_Tradelane_1
-pos = 7027, 0, 61306
+pos = 6780, 0, 62531
 rotate = 0, 169, 0
 shape = BOX
-size = 800, 1200, 48598
+size = 800, 1200, 46598
 ids_info = 461248
 ;res $Trade_Lane_Ring_info
 comment = .                Tradelane to Leeds
@@ -657,7 +657,7 @@ faction = co_ti_grp, 0.08
 [Object]
 nickname = Br04_Trade_Lane_Ring_8
 ids_name = 260679
-pos = 13365, 0, 33121
+pos = 14521, 0, 30571
 rotate = 0, -24, 0
 archetype = Trade_Lane_Ring
 next_ring = Br04_Trade_Lane_Ring_9
@@ -673,7 +673,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_9
 ids_name = 260679
-pos = 16627, 0, 25926
+pos = 17618, 0, 23741
 rotate = 0, -24, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_8
@@ -689,7 +689,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_10
 ids_name = 260679
-pos = 19889, 0, 18731
+pos = 20715, 0, 16910
 rotate = 0, -24, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_9
@@ -705,7 +705,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_11
 ids_name = 260679
-pos = 23151, 0, 11536
+pos = 23812, 0, 10079
 rotate = 0, -24, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_10
@@ -721,7 +721,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_12
 ids_name = 260679
-pos = 26413, 0, 4341
+pos = 26908, 0, 3248
 rotate = 0, -24, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_11
@@ -737,7 +737,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_13
 ids_name = 260679
-pos = 29675, 0, -2854
+pos = 30005, 0, -3583
 rotate = 0, -24, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_12
@@ -753,7 +753,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_14
 ids_name = 260679
-pos = 32937, 0, -10049
+pos = 33102, 0, -10414
 rotate = 0, -24, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_13
@@ -785,7 +785,7 @@ pilot = pilot_solar_ace
 
 [zone]
 nickname = Zone_Br04_Tradelane_2
-pos = 24741, 0, 8029
+pos = 25360, 0, 6663
 rotate = 0, -24, 0
 shape = BOX
 size = 800,54098
@@ -1744,7 +1744,7 @@ nickname = Br04_02
 ids_name = 460017
 ;res str stokes
 ; Stokes Smelter
-pos = 37995, 0, -19398
+pos = 37695, 0, -18898
 archetype = space_factory01
 ids_info = 65681
 base = Br04_02_Base
@@ -1760,7 +1760,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_stokes_mplatform_1
 ids_name = 60213
-pos = 38487, -21, -19937
+pos = 38187, -21, -19437
 archetype = mplatform
 reputation = br_m_grp
 parent = Br04_02
@@ -1772,7 +1772,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_space_tankl4_2
 ids_name = 60251
-pos = 38489, 0, -18883
+pos = 38189, 0, -18383
 archetype = space_tankl4
 reputation = br_m_grp
 parent = Br04_02
@@ -1780,7 +1780,7 @@ parent = Br04_02
 [Object]
 nickname = Br04_space_tankl4x4_1
 ids_name = 60251
-pos = 38690, 0, -19397
+pos = 38390, 0, -18897
 rotate = 0, 90, 0
 archetype = space_tankl4x4
 reputation = br_m_grp
@@ -1789,7 +1789,7 @@ parent = Br04_02
 [Object]
 nickname = Br04_stokes_platform_2
 ids_name = 60213
-pos = 39025, -21, -18920
+pos = 38725, -21, -18420
 rotate = 0, 180, 0
 archetype = mplatform
 reputation = br_m_grp
@@ -4591,7 +4591,7 @@ faction = br_m_grp, 1
 
 [Object]
 nickname = Br04_space_industrial01_1
-pos = 39030, 0, -19151
+pos = 38730, 0, -18651
 rotate = 0, -90, 0
 archetype = space_industrial01
 reputation = br_m_grp

--- a/DATA/UNIVERSE/SYSTEMS/Br04/Br04.ini
+++ b/DATA/UNIVERSE/SYSTEMS/Br04/Br04.ini
@@ -511,7 +511,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_1
 ids_name = 260677
-pos = 11224, 0, 40474
+pos = 11718, 0, 38023
 rotate = 0, 169, 0
 archetype = Trade_Lane_Ring
 next_ring = Br04_Trade_Lane_Ring_2
@@ -527,7 +527,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_2
 ids_name = 260677
-pos = 9743, 0, 47826
+pos = 10089, 0, 46111
 rotate = 0, 169, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_1
@@ -543,7 +543,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_3
 ids_name = 260677
-pos = 8261, 0, 55178
+pos = 8459, 0, 54198
 rotate = 0, 169, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_2
@@ -559,7 +559,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_4
 ids_name = 260677
-pos = 6780, 0, 62531
+pos = 6830, 0, 62286
 rotate = 0, 169, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_3
@@ -575,7 +575,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_5
 ids_name = 260677
-pos = 5299, 0, 69883
+pos = 5200, 0, 70374
 rotate = 0, 169, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_4
@@ -591,7 +591,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_6
 ids_name = 260677
-pos = 3818, 0, 77235
+pos = 3571, 0, 78461
 rotate = 0, 169, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_5
@@ -607,7 +607,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_7
 ids_name = 260677
-pos = 2336, 0, 84587
+pos = 1941, 0, 86549
 rotate = 0, 169, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_6
@@ -625,7 +625,7 @@ nickname = Zone_Br04_Tradelane_1
 pos = 6780, 0, 62531
 rotate = 0, 169, 0
 shape = BOX
-size = 800, 1200, 46598
+size = 800, 1200, 51598
 ids_info = 461248
 ;res $Trade_Lane_Ring_info
 comment = .                Tradelane to Leeds
@@ -1090,7 +1090,7 @@ Music = zone_field_asteroid_rock
 [Object]
 nickname = Br04_06
 ids_name = 196680
-pos = 1083, 0, 86933
+pos = 1083, 0, 87433
 archetype = depot
 ids_info = 65673
 base = Br04_06_Base
@@ -1105,7 +1105,7 @@ pilot = pilot_solar_ace
 
 [Object]
 nickname = Br04_06_modul_outpost_tower_01
-pos = 1083, -61, 86823
+pos = 1083, -61, 87323
 archetype = modul_outpost_tower
 parent = Br04_06
 reputation = br_p_grp
@@ -1114,7 +1114,7 @@ visit = 128
 [Object]
 nickname = Br04_06_modul_outpost_tower_02
 rotate = 0, 0, -180
-pos = 1083, -153, 86823
+pos = 1083, -153, 87323
 archetype = modul_outpost_tower
 parent = Br04_06
 reputation = br_p_grp
@@ -1123,7 +1123,7 @@ visit = 128
 [Object]
 nickname = Br04_06_modul_outpost_cupola_01
 rotate = -90, 0, 0
-pos = 1083, -174, 87174
+pos = 1083, -174, 87674
 archetype = modul_outpost_cupola
 parent = Br04_06
 reputation = br_p_grp
@@ -1131,7 +1131,7 @@ visit = 128
 
 [Object]
 nickname = Br04_06_modul_storage_octagonal_01
-pos = 1083, -174, 86991
+pos = 1083, -174, 87491
 archetype = modul_storage_octagonal
 parent = Br04_06
 reputation = br_p_grp
@@ -1139,7 +1139,7 @@ visit = 128
 
 [Object]
 nickname = Br04_06_modul_radar_windows_01
-pos = 1083, -91, 86991
+pos = 1083, -91, 87491
 archetype = modul_radar_windows
 parent = Br04_06
 reputation = br_p_grp
@@ -1744,7 +1744,7 @@ nickname = Br04_02
 ids_name = 460017
 ;res str stokes
 ; Stokes Smelter
-pos = 37695, 0, -18898
+pos = 37995, 0, -19398
 archetype = space_factory01
 ids_info = 65681
 base = Br04_02_Base
@@ -1760,7 +1760,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_stokes_mplatform_1
 ids_name = 60213
-pos = 38187, -21, -19437
+pos = 38487, -21, -19937
 archetype = mplatform
 reputation = br_m_grp
 parent = Br04_02
@@ -1772,7 +1772,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_space_tankl4_2
 ids_name = 60251
-pos = 38189, 0, -18383
+pos = 38489, 0, -18883
 archetype = space_tankl4
 reputation = br_m_grp
 parent = Br04_02
@@ -1780,7 +1780,7 @@ parent = Br04_02
 [Object]
 nickname = Br04_space_tankl4x4_1
 ids_name = 60251
-pos = 38390, 0, -18897
+pos = 38690, 0, -19397
 rotate = 0, 90, 0
 archetype = space_tankl4x4
 reputation = br_m_grp
@@ -1789,7 +1789,7 @@ parent = Br04_02
 [Object]
 nickname = Br04_stokes_platform_2
 ids_name = 60213
-pos = 38725, -21, -18420
+pos = 39025, -21, -18920
 rotate = 0, 180, 0
 archetype = mplatform
 reputation = br_m_grp
@@ -4591,7 +4591,7 @@ faction = br_m_grp, 1
 
 [Object]
 nickname = Br04_space_industrial01_1
-pos = 38730, 0, -18651
+pos = 39030, 0, -19151
 rotate = 0, -90, 0
 archetype = space_industrial01
 reputation = br_m_grp

--- a/DATA/UNIVERSE/SYSTEMS/Br04/Br04.ini
+++ b/DATA/UNIVERSE/SYSTEMS/Br04/Br04.ini
@@ -511,7 +511,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_1
 ids_name = 260677
-pos = 11224, 0, 40474
+pos = 11718, 0, 38023
 rotate = 0, 169, 0
 archetype = Trade_Lane_Ring
 next_ring = Br04_Trade_Lane_Ring_2
@@ -527,7 +527,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_2
 ids_name = 260677
-pos = 9743, 0, 47826
+pos = 10154, 0, 45784
 rotate = 0, 169, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_1
@@ -543,7 +543,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_3
 ids_name = 260677
-pos = 8261, 0, 55178
+pos = 8591, 0, 53545
 rotate = 0, 169, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_2
@@ -559,7 +559,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_4
 ids_name = 260677
-pos = 6780, 0, 62531
+pos = 7027, 0, 61306
 rotate = 0, 169, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_3
@@ -575,7 +575,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_5
 ids_name = 260677
-pos = 5299, 0, 69883
+pos = 5463, 0, 69067
 rotate = 0, 169, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_4
@@ -591,7 +591,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_6
 ids_name = 260677
-pos = 3818, 0, 77235
+pos = 3900, 0, 76827
 rotate = 0, 169, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_5
@@ -622,10 +622,10 @@ pilot = pilot_solar_ace
 
 [zone]
 nickname = Zone_Br04_Tradelane_1
-pos = 6780, 0, 62531
+pos = 7027, 0, 61306
 rotate = 0, 169, 0
 shape = BOX
-size = 800, 1200, 46598
+size = 800, 1200, 48598
 ids_info = 461248
 ;res $Trade_Lane_Ring_info
 comment = .                Tradelane to Leeds
@@ -657,7 +657,7 @@ faction = co_ti_grp, 0.08
 [Object]
 nickname = Br04_Trade_Lane_Ring_8
 ids_name = 260679
-pos = 14521, 0, 30571
+pos = 13365, 0, 33121
 rotate = 0, -24, 0
 archetype = Trade_Lane_Ring
 next_ring = Br04_Trade_Lane_Ring_9
@@ -673,7 +673,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_9
 ids_name = 260679
-pos = 17618, 0, 23741
+pos = 16627, 0, 25926
 rotate = 0, -24, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_8
@@ -689,7 +689,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_10
 ids_name = 260679
-pos = 20715, 0, 16910
+pos = 19889, 0, 18731
 rotate = 0, -24, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_9
@@ -705,7 +705,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_11
 ids_name = 260679
-pos = 23812, 0, 10079
+pos = 23151, 0, 11536
 rotate = 0, -24, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_10
@@ -721,7 +721,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_12
 ids_name = 260679
-pos = 26908, 0, 3248
+pos = 26413, 0, 4341
 rotate = 0, -24, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_11
@@ -737,7 +737,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_13
 ids_name = 260679
-pos = 30005, 0, -3583
+pos = 29675, 0, -2854
 rotate = 0, -24, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_12
@@ -753,7 +753,7 @@ pilot = pilot_solar_ace
 [Object]
 nickname = Br04_Trade_Lane_Ring_14
 ids_name = 260679
-pos = 33102, 0, -10414
+pos = 32937, 0, -10049
 rotate = 0, -24, 0
 archetype = Trade_Lane_Ring
 prev_ring = Br04_Trade_Lane_Ring_13
@@ -785,7 +785,7 @@ pilot = pilot_solar_ace
 
 [zone]
 nickname = Zone_Br04_Tradelane_2
-pos = 25360, 0, 6663
+pos = 24741, 0, 8029
 rotate = 0, -24, 0
 shape = BOX
 size = 800,54098


### PR DESCRIPTION
Set standard distance of 2-2.5k from gates and dock rings.
Updated tradelane zone lengths to match.
Moved Stokes slightly because the lanes are at crazy angles so this was easier.
Moved Durham slightly to keep it closer than the new TLR distance.