### PR TITLE
Sun death zone update

### DIFF
--- a/DATA/UNIVERSE/SYSTEMS/BR01/br01.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BR01/br01.ini
@@ -2254,6 +2254,16 @@ reputation = co_nws_grp
 parent = Br01_07
 
 [zone]
+nickname = Zone_Br01_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 8500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_Br01_sun_death
 pos = 0, 0, 0
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/BR02/br02.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BR02/br02.ini
@@ -1439,11 +1439,21 @@ reputation = br_m_grp
 parent = Br02_space_tanklx4_2
 
 [zone]
+nickname = Zone_Br02_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 6500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_Br02_sun_death
 pos = 0, 0, 0
 shape = SPHERE
 size = 8000
-damage = 1000
+damage = 250000
 sort = 99.5
 density = 0
 relief_time = 0

--- a/DATA/UNIVERSE/SYSTEMS/BR03/br03.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BR03/br03.ini
@@ -1781,6 +1781,16 @@ parent = Br03_04
 nickname = Zone_Br03_sun_death
 pos = 0, 0, 0
 shape = SPHERE
+size = 8500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+
+[zone]
+nickname = Zone_Br03_sun_death
+pos = 0, 0, 0
+shape = SPHERE
 size = 10000
 damage = 250000
 sort = 99.5

--- a/DATA/UNIVERSE/SYSTEMS/BR04/br04.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BR04/br04.ini
@@ -231,11 +231,21 @@ burn_color = 160, 222, 245
 ids_info = 66163
 
 [zone]
+nickname = zone_br04_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 8500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+
+[zone]
 nickname = zone_br04_sun_death
 pos = 0, 0, 0
 shape = SPHERE
 size = 10000
-damage = 2000000
+damage = 250000
 sort = 99.5
 density = 0
 relief_time = 0

--- a/DATA/UNIVERSE/SYSTEMS/BR05/br05.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BR05/br05.ini
@@ -1024,6 +1024,16 @@ ids_info = 66147
 nickname = Zone_Br05_sun_death
 pos = 0, 0, 0
 shape = SPHERE
+size = 6500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+
+[zone]
+nickname = Zone_Br05_sun_death
+pos = 0, 0, 0
+shape = SPHERE
 size = 8000
 damage = 250000
 sort = 99.5

--- a/DATA/UNIVERSE/SYSTEMS/BR06/br06.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BR06/br06.ini
@@ -1472,11 +1472,31 @@ base = br_n_battleship_base
 dock_with = br_n_battleship_base
 
 [zone]
+nickname = Zone_Br06_sun1_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 8500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_Br06_sun1_death
 pos = 0, 0, 0
 shape = SPHERE
 size = 10000
 damage = 250000
+sort = 99.5
+density = 0
+relief_time = 0
+
+[zone]
+nickname = Zone_Br06_sun2_superdeath
+pos = -7780, 0, -7462
+shape = SPHERE
+size = 8500
+damage = 250000000
 sort = 99.5
 density = 0
 relief_time = 0

--- a/DATA/UNIVERSE/SYSTEMS/BW01/bw01.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BW01/bw01.ini
@@ -3377,6 +3377,16 @@ density = 0
 relief_time = 0
 
 [zone]
+nickname = Zone_Bw01_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 5500
+damage = 250000000
+sort = 99.500000
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_Bw01_sun_death
 pos = 0, 0, 0
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/BW04/bw04.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BW04/bw04.ini
@@ -372,6 +372,17 @@ faction = fc_rh_grp, 1
 Music = zone_field_asteroid_lava
 
 [zone]
+nickname = Zone_Bw04_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 12000
+property_flags = 131072
+damage = 250000000
+sort = 99
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_Bw04_sun_death
 pos = 0, 0, 0
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/BW05/bw05.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BW05/bw05.ini
@@ -831,11 +831,31 @@ visit = 128
 sort = 99
 
 [zone]
+nickname = Zone_Bw05_sun1_superdeath
+pos = -38, 0, -117
+shape = SPHERE
+size = 2500
+damage = 25000000
+sort = 99
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_Bw05_sun1_death
 pos = -38, 0, -117
 shape = SPHERE
 size = 4000
 damage = 250000
+sort = 99
+density = 0
+relief_time = 0
+
+[zone]
+nickname = Zone_Bw05_sun2_superdeath
+pos = 22326, 0, -10202
+shape = SPHERE
+size = 5500
+damage = 250000000
 sort = 99
 density = 0
 relief_time = 0

--- a/DATA/UNIVERSE/SYSTEMS/BW05/bw05.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BW05/bw05.ini
@@ -374,7 +374,7 @@ ids_info = 66152
 
 [zone]
 nickname = Zone_Bw05_sun2_exclusion
-pos = 22279, 0, -10250
+pos = 22158, 0, -10373
 shape = SPHERE
 size = 8000
 property_flags = 65536
@@ -832,7 +832,7 @@ sort = 99
 
 [zone]
 nickname = Zone_Bw05_sun1_superdeath
-pos = -38, 0, -117
+pos = 0, 0, 0
 shape = SPHERE
 size = 2500
 damage = 25000000
@@ -842,7 +842,7 @@ relief_time = 0
 
 [zone]
 nickname = Zone_Bw05_sun1_death
-pos = -38, 0, -117
+pos = 0, 0, 0
 shape = SPHERE
 size = 4000
 damage = 250000
@@ -852,7 +852,7 @@ relief_time = 0
 
 [zone]
 nickname = Zone_Bw05_sun2_superdeath
-pos = 22326, 0, -10202
+pos = 22158, 0, -10373
 shape = SPHERE
 size = 5500
 damage = 250000000
@@ -862,7 +862,7 @@ relief_time = 0
 
 [zone]
 nickname = Zone_Bw05_sun2_death
-pos = 22326, 0, -10202
+pos = 22158, 0, -10373
 shape = SPHERE
 size = 7000
 damage = 250000

--- a/DATA/UNIVERSE/SYSTEMS/BW06/bw06.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BW06/bw06.ini
@@ -1581,7 +1581,7 @@ faction = fc_c_grp, 1
 
 [zone]
 nickname = Zone_Bw06_sun1_superdeath
-pos = 172, 0, 627
+pos = 174, 0, 636
 shape = SPHERE
 size = 4500
 damage = 250000000
@@ -1591,7 +1591,7 @@ relief_time = 0
 
 [zone]
 nickname = Zone_Bw06_sun1_death
-pos = 172, 0, 627
+pos = 174, 0, 636
 shape = SPHERE
 size = 6000
 damage = 250000
@@ -1601,7 +1601,7 @@ relief_time = 0
 
 [zone]
 nickname = Zone_Bw06_sun2_superdeath
-pos = -5187, 0, 11358
+pos = -5200, 0, 11386
 shape = SPHERE
 size = 4500
 damage = 250000000
@@ -1611,7 +1611,7 @@ relief_time = 0
 
 [zone]
 nickname = Zone_Bw06_sun2_death
-pos = -5187, 0, 11358
+pos = -5200, 0, 11386
 shape = SPHERE
 size = 6000
 damage = 250000
@@ -1621,7 +1621,7 @@ relief_time = 0
 
 [zone]
 nickname = Zone_Bw06_sun3_superdeath
-pos = -17030, 0, 11173
+pos = -17028, 0, 11113
 shape = SPHERE
 size = 4500
 damage = 250000000
@@ -1631,7 +1631,7 @@ relief_time = 0
 
 [zone]
 nickname = Zone_Bw06_sun3_death
-pos = -17030, 0, 11173
+pos = -17028, 0, 11113
 shape = SPHERE
 size = 6000
 damage = 250000

--- a/DATA/UNIVERSE/SYSTEMS/BW06/bw06.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BW06/bw06.ini
@@ -1580,6 +1580,16 @@ encounter = patrolp_assault_pirate_raid_co, 19, 0.290000
 faction = fc_c_grp, 1
 
 [zone]
+nickname = Zone_Bw06_sun1_superdeath
+pos = 172, 0, 627
+shape = SPHERE
+size = 4500
+damage = 250000000
+sort = 99.500000
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_Bw06_sun1_death
 pos = 172, 0, 627
 shape = SPHERE
@@ -1590,11 +1600,31 @@ density = 0
 relief_time = 0
 
 [zone]
+nickname = Zone_Bw06_sun2_superdeath
+pos = -5187, 0, 11358
+shape = SPHERE
+size = 4500
+damage = 250000000
+sort = 99.500000
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_Bw06_sun2_death
 pos = -5187, 0, 11358
 shape = SPHERE
 size = 6000
 damage = 250000
+sort = 99.500000
+density = 0
+relief_time = 0
+
+[zone]
+nickname = Zone_Bw06_sun3_superdeath
+pos = -17030, 0, 11173
+shape = SPHERE
+size = 4500
+damage = 250000000
 sort = 99.500000
 density = 0
 relief_time = 0

--- a/DATA/UNIVERSE/SYSTEMS/BW07/bw07.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BW07/bw07.ini
@@ -553,11 +553,31 @@ loadout = cv_loadout_solar_jumpgate01
 pilot = pilot_solar_ace
 
 [zone]
+nickname = Zone_Bw07_sun2_superdeath
+pos = 21251, 0, -6634
+shape = SPHERE
+size = 5500
+damage = 250000000
+sort = 99
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_Bw07_sun2_death
 pos = 21251, 0, -6634
 shape = SPHERE
 size = 7000
 damage = 250000
+sort = 99
+density = 0
+relief_time = 0
+
+[zone]
+nickname = Zone_Bw07_sun1_superdeath
+pos = 3505, 0, 2669
+shape = SPHERE
+size = 6500
+damage = 250000000
 sort = 99
 density = 0
 relief_time = 0

--- a/DATA/UNIVERSE/SYSTEMS/BW07/bw07.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BW07/bw07.ini
@@ -209,7 +209,7 @@ sort = 99
 [Object]
 nickname = Bw07_sun1
 ids_name = 261043
-pos = 3803, 0, 2669
+pos = 3505, 0, 2669
 archetype = sun_1000
 star = sm_blue_sun
 atmosphere_range = 9000
@@ -218,7 +218,7 @@ ids_info = 66151
 [Object]
 nickname = Bw07_sun2
 ids_name = 261042
-pos = 21102, 0, -6634
+pos = 21251, 0, -6634
 archetype = sun_1000
 star = ku03_sun2
 atmosphere_range = 8000

--- a/DATA/UNIVERSE/SYSTEMS/BW08/bw08.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BW08/bw08.ini
@@ -1985,6 +1985,16 @@ encounter = patrolp_assault, 19, 0.29
 faction = br_m_grp, 1
 
 [zone]
+nickname = Zone_Bw08_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 4500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_Bw08_sun_death
 pos = 0, 0, 0
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/BW09/bw09.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BW09/bw09.ini
@@ -737,6 +737,16 @@ visit = 128
 sort = 99
 
 [zone]
+nickname = Zone_Bw09_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 7500
+damage = 250000000
+sort = 99
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_Bw09_death_sun
 pos = 0, 0, 0
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/BW10/bw10.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BW10/bw10.ini
@@ -243,7 +243,7 @@ rotate = -90, 0, 180
 ambient_color = 255, 255, 255
 Archetype = sun_2000
 star = Bw10_Sun
-atmosphere_range = 13000
+atmosphere_range = 12000
 burn_color = 160, 222, 245
 visit = 0
 ids_info = 66154
@@ -732,10 +732,20 @@ visit = 128
 sort = 99
 
 [zone]
+nickname = Zone_Bw10_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 9500
+damage = 250000000
+sort = 99
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_Bw10_death_sun
 pos = 0, 0, 0
 shape = SPHERE
-size = 12000
+size = 11000
 damage = 250000
 sort = 99
 density = 0

--- a/DATA/UNIVERSE/SYSTEMS/BW11/bw11.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BW11/bw11.ini
@@ -107,10 +107,20 @@ star = sm_white_sun
 atmosphere_range = 7500
 
 [zone]
-nickname = Bw11_Sun1_death
+nickname = Bw11_Sun1_superdeath
 pos = -1000, 500, -1500
 shape = SPHERE
 size = 5000
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+
+[zone]
+nickname = Bw11_Sun1_death
+pos = -1000, 500, -1500
+shape = SPHERE
+size = 6500
 damage = 250000
 sort = 99.5
 density = 0

--- a/DATA/UNIVERSE/SYSTEMS/BW11/bw11.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BW11/bw11.ini
@@ -108,7 +108,7 @@ atmosphere_range = 7500
 
 [zone]
 nickname = Bw11_Sun1_superdeath
-pos = -1000, 500, -1500
+pos = 0, 0, 0
 shape = SPHERE
 size = 5000
 damage = 250000000
@@ -118,7 +118,7 @@ relief_time = 0
 
 [zone]
 nickname = Bw11_Sun1_death
-pos = -1000, 500, -1500
+pos = 0, 0, 0
 shape = SPHERE
 size = 6500
 damage = 250000

--- a/DATA/UNIVERSE/SYSTEMS/EW01/ew01.ini
+++ b/DATA/UNIVERSE/SYSTEMS/EW01/ew01.ini
@@ -443,28 +443,8 @@ sort = 99
 ids_info = 65909
 
 [zone]
-nickname = Zone_Ew01_sun_superdeath
-pos = 0, 0, 0
-shape = SPHERE
-size = 3000
-damage = 250000000
-sort = 99
-density = 0
-relief_time = 0
-
-[zone]
 nickname = Zone_Ew01_sun_death
 pos = 0, 0, 0
-shape = SPHERE
-size = 3000
-damage = 250000
-sort = 99
-density = 0
-relief_time = 0
-
-[zone]
-nickname = Zone_Ew01_sun2_superdeath
-pos = 1723, 30000, -1378
 shape = SPHERE
 size = 3000
 damage = 250000000
@@ -477,7 +457,7 @@ nickname = Zone_Ew01_sun2_death
 pos = 1723, 30000, -1378
 shape = SPHERE
 size = 3000
-damage = 250000
+damage = 250000000
 sort = 99
 density = 0
 relief_time = 0

--- a/DATA/UNIVERSE/SYSTEMS/EW01/ew01.ini
+++ b/DATA/UNIVERSE/SYSTEMS/EW01/ew01.ini
@@ -443,11 +443,31 @@ sort = 99
 ids_info = 65909
 
 [zone]
+nickname = Zone_Ew01_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 3000
+damage = 250000000
+sort = 99
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_Ew01_sun_death
 pos = 0, 0, 0
 shape = SPHERE
 size = 3000
 damage = 250000
+sort = 99
+density = 0
+relief_time = 0
+
+[zone]
+nickname = Zone_Ew01_sun2_superdeath
+pos = 1723, 30000, -1378
+shape = SPHERE
+size = 3000
+damage = 250000000
 sort = 99
 density = 0
 relief_time = 0

--- a/DATA/UNIVERSE/SYSTEMS/EW03/ew03.ini
+++ b/DATA/UNIVERSE/SYSTEMS/EW03/ew03.ini
@@ -157,10 +157,20 @@ pos = 50, 0, 262
 rotate = 30, 0, 0
 archetype = planet_neutron_800
 spin = 0.020000, 0.020000, 0.020000
-atmosphere_range = 900
+atmosphere_range = 2000
 burn_color = 255, 222, 160
 ring = Zone_Ew03_gravity_ring, solar\rings\lava.ini
 ids_info = 66164
+
+[zone]
+nickname = Zone_Ew03_neutron_star_superdeath
+pos = 50, 0, 262
+shape = SPHERE
+size = 1600
+damage = 250000000
+sort = 99
+density = 0
+relief_time = 0
 
 [Object]
 nickname = Ew03_01

--- a/DATA/UNIVERSE/SYSTEMS/EW04/ew04.ini
+++ b/DATA/UNIVERSE/SYSTEMS/EW04/ew04.ini
@@ -453,6 +453,16 @@ density = 0
 relief_time = 0
 
 [zone]
+nickname = Zone_EW04_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 3500
+damage = 250000000
+sort = 99
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_EW04_sun_death
 pos = 0, 0, 0
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/EW05/ew05.ini
+++ b/DATA/UNIVERSE/SYSTEMS/EW05/ew05.ini
@@ -45,6 +45,17 @@ atmosphere_range = 8000
 ids_info = 66155
 
 [Zone]
+nickname = Zone_Ew05_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 5500
+damage = 250000000
+visit = 128
+sort = 99.5
+density = 0
+relief_time = 0
+
+[Zone]
 nickname = Zone_Ew05_sun_death
 pos = 0, 0, 0
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/EW06/ew06.ini
+++ b/DATA/UNIVERSE/SYSTEMS/EW06/ew06.ini
@@ -73,11 +73,33 @@ type = DIRECTIONAL
 atten_curve = DYNAMIC_DIRECTION
 
 [zone]
+nickname = Zone_Ew06_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 5500
+damage = 250000000
+visit = 128
+sort = 99.5
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_Ew06_sun_death
 pos = 0, 0, 0
 shape = SPHERE
 size = 7000
 damage = 250000
+visit = 128
+sort = 99.5
+density = 0
+relief_time = 0
+
+[zone]
+nickname = Zone_Ew06_sun2_superdeath
+pos = 145000, 0, -130000
+shape = SPHERE
+size = 5500
+damage = 250000000
 visit = 128
 sort = 99.5
 density = 0

--- a/DATA/UNIVERSE/SYSTEMS/HI01/hi01.ini
+++ b/DATA/UNIVERSE/SYSTEMS/HI01/hi01.ini
@@ -847,6 +847,16 @@ encounter = patrolp_bh_assault, 19, 0.4
 faction = gd_bh_grp, 1
 
 [zone]
+nickname = Zone_Hi01_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 4500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_Hi01_sun_death
 pos = 0, 0, 0
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/HI02/hi02.ini
+++ b/DATA/UNIVERSE/SYSTEMS/HI02/hi02.ini
@@ -435,6 +435,16 @@ reputation = fc_c_grp
 parent = Hi02_02
 
 [zone]
+nickname = Zone_Hi02_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 5500
+damage = 250000000
+sort = 99
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_Hi02_sun_death
 pos = 0, 0, 0
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/IW01/iw01.ini
+++ b/DATA/UNIVERSE/SYSTEMS/IW01/iw01.ini
@@ -2214,7 +2214,7 @@ sort = 99.500000
 
 [zone]
 nickname = ZONE_Iw01_sun_superdeath
-pos = 9, 0, 28
+pos = 0, 0, 0
 shape = SPHERE
 size = 4500
 damage = 250000000
@@ -2223,7 +2223,7 @@ population_additive = false
 
 [zone]
 nickname = ZONE_Iw01_sun_death
-pos = 9, 0, 28
+pos = 0, 0, 0
 shape = SPHERE
 size = 6000
 damage = 250000

--- a/DATA/UNIVERSE/SYSTEMS/IW01/iw01.ini
+++ b/DATA/UNIVERSE/SYSTEMS/IW01/iw01.ini
@@ -192,6 +192,7 @@ pos = 0, 0, 0
 ambient_color = 255, 255, 255
 archetype = sun_1000
 star = med_yellow_sun
+atmosphere_range = 7000
 ids_info = 66163
 
 [Object]
@@ -2212,11 +2213,20 @@ visit = 128
 sort = 99.500000
 
 [zone]
+nickname = ZONE_Iw01_sun_superdeath
+pos = 9, 0, 28
+shape = SPHERE
+size = 4500
+damage = 250000000
+sort = 99.500000
+population_additive = false
+
+[zone]
 nickname = ZONE_Iw01_sun_death
 pos = 9, 0, 28
 shape = SPHERE
 size = 6000
-damage = 100
+damage = 250000
 sort = 99.500000
 population_additive = false
 

--- a/DATA/UNIVERSE/SYSTEMS/IW02/iw02.ini
+++ b/DATA/UNIVERSE/SYSTEMS/IW02/iw02.ini
@@ -179,6 +179,7 @@ ids_name = 261033
 pos = 0, 0, 0
 ambient_color = 255, 255, 255
 star = med_blue_sun
+atmosphere_range = 7000
 ids_info = 66158
 archetype = sun_2000
 
@@ -2142,11 +2143,21 @@ sort = 99.5
 vignette_type = field
 
 [zone]
-nickname = ZONE_Iw02_Sun_death
-pos = -4, 0, -13
+nickname = ZONE_Iw02_Sun_superdeath
+pos = 0, 0, 0
 shape = SPHERE
-size = 5000
-damage = 10000
+size = 4500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+
+[zone]
+nickname = ZONE_Iw02_Sun_death
+pos = 0, 0, 0
+shape = SPHERE
+size = 6000
+damage = 250000
 sort = 99.5
 density = 0
 relief_time = 0

--- a/DATA/UNIVERSE/SYSTEMS/IW04/iw04.ini
+++ b/DATA/UNIVERSE/SYSTEMS/IW04/iw04.ini
@@ -1947,6 +1947,17 @@ encounter = patrolp_assault_pirate_raid, 13, 0.29
 faction = fc_lh_grp, 1
 
 [zone]
+nickname = Zone_Iw04_sun_superdeath
+pos = -41, 0, 43
+shape = SPHERE
+size = 5500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+population_additive = false
+
+[zone]
 nickname = Zone_Iw04_sun_death
 pos = -41, 0, 43
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/IW04/iw04.ini
+++ b/DATA/UNIVERSE/SYSTEMS/IW04/iw04.ini
@@ -1948,7 +1948,7 @@ faction = fc_lh_grp, 1
 
 [zone]
 nickname = Zone_Iw04_sun_superdeath
-pos = -41, 0, 43
+pos = 0, 0, 0
 shape = SPHERE
 size = 5500
 damage = 250000000
@@ -1959,7 +1959,7 @@ population_additive = false
 
 [zone]
 nickname = Zone_Iw04_sun_death
-pos = -41, 0, 43
+pos = 0, 0, 0
 shape = SPHERE
 size = 7000
 damage = 250000

--- a/DATA/UNIVERSE/SYSTEMS/KU01/ku01.ini
+++ b/DATA/UNIVERSE/SYSTEMS/KU01/ku01.ini
@@ -1991,6 +1991,17 @@ relief_time = 0
 population_additive = false
 
 [zone]
+nickname = Zone_Ku01_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 8500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+population_additive = false
+
+[zone]
 nickname = Zone_Ku01_sun_death
 pos = 0, 0, 0
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/KU02/ku02.ini
+++ b/DATA/UNIVERSE/SYSTEMS/KU02/ku02.ini
@@ -1325,6 +1325,17 @@ archetype = fuchu_core
 ring = Zone_Ku02_Fuchu_ring, solar\rings\fuchu.ini
 
 [zone]
+nickname = Zone_Ku02_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 10500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+population_additive = false
+
+[zone]
 nickname = Zone_Ku02_sun_death
 pos = 0, 0, 0
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/KU03/ku03.ini
+++ b/DATA/UNIVERSE/SYSTEMS/KU03/ku03.ini
@@ -1170,8 +1170,19 @@ loadout = ku_loadout_solar_weapon_platform01
 pilot = pilot_solar_ace
 
 [zone]
+nickname = Zone_Ku03_sun1_superdeath
+pos = -8626, 0, -3265
+shape = SPHERE
+size = 9500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+population_additive = false
+
+[zone]
 nickname = Zone_Ku03_sun1_death
-pos = -8648, 0, -3242
+pos = -8626, 0, -3265
 shape = SPHERE
 size = 11000
 damage = 250000
@@ -1181,8 +1192,19 @@ relief_time = 0
 population_additive = false
 
 [zone]
+nickname = Zone_Ku03_sun2_superdeath
+pos = 19166, 5000, 18945
+shape = SPHERE
+size = 9500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+population_additive = false
+
+[zone]
 nickname = Zone_Ku03_sun2_death
-pos = 19215, 5000, 18894
+pos = 19166, 5000, 18945
 shape = SPHERE
 size = 11000
 damage = 250000

--- a/DATA/UNIVERSE/SYSTEMS/KU04/ku04.ini
+++ b/DATA/UNIVERSE/SYSTEMS/KU04/ku04.ini
@@ -2127,6 +2127,16 @@ visit = 0
 goto = Ku06, Ku06_to_Ku04_hole, gate_tunnel_bretonia
 
 [zone]
+nickname = Zone_Ku04_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 8500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_Ku04_sun_death
 pos = 0, 0, 0
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/KU05/ku05.ini
+++ b/DATA/UNIVERSE/SYSTEMS/KU05/ku05.ini
@@ -355,8 +355,18 @@ faction = co_me_grp, 0.33
 faction = co_shi_grp, 0.67
 
 [zone]
+nickname = Zone_Ku05_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 8500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_Ku05_sun_death
-pos = 32, 0, 444
+pos = 0, 0, 0
 shape = SPHERE
 size = 10000
 damage = 250000

--- a/DATA/UNIVERSE/SYSTEMS/KU07/ku07.ini
+++ b/DATA/UNIVERSE/SYSTEMS/KU07/ku07.ini
@@ -83,8 +83,18 @@ pos = 0, 0, 0
 ambient_color = 255, 255, 255
 Archetype = sun_2000
 star = edge_sun
-atmosphere_range = 9000
+atmosphere_range = 8000
 ids_info = 66160
+
+[zone]
+nickname = Zone_Ku07_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 5500
+damage = 250000000
+sort = 99.500000
+density = 0
+relief_time = 0
 
 [zone]
 nickname = Zone_Ku07_sun_death

--- a/DATA/UNIVERSE/SYSTEMS/LI01/li01.ini
+++ b/DATA/UNIVERSE/SYSTEMS/LI01/li01.ini
@@ -10552,6 +10552,17 @@ encounter = patrolp_assault, 16, 0.290000
 faction = li_n_grp, 1
 
 [zone]
+nickname = Zone_Li01_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 8500
+damage = 250000000
+sort = 99.500000
+density = 0
+relief_time = 0
+population_additive = false
+
+[zone]
 nickname = Zone_Li01_sun_death
 pos = 0, 0, 0
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/LI02/li02.ini
+++ b/DATA/UNIVERSE/SYSTEMS/LI02/li02.ini
@@ -221,10 +221,21 @@ burn_color = 160, 222, 245
 star = Li02_Sun
 
 [zone]
+nickname = zone_Li02_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 9500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+population_additive = false
+
+[zone]
 nickname = zone_Li02_sun_death
 pos = 0, 0, 0
 shape = SPHERE
-size = 12000
+size = 11000
 damage = 250000
 sort = 99.5
 density = 0

--- a/DATA/UNIVERSE/SYSTEMS/LI03/li03.ini
+++ b/DATA/UNIVERSE/SYSTEMS/LI03/li03.ini
@@ -5068,6 +5068,17 @@ pos = -60820, 0, 2254
 Archetype = debris_xlarge01
 
 [zone]
+nickname = Zone_Li03_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 11500
+damage = 250000000
+sort = 99.500000
+density = 0
+relief_time = 0
+population_additive = false
+
+[zone]
 nickname = Zone_Li03_sun_death
 pos = 0, 0, 0
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/LI04/li04.ini
+++ b/DATA/UNIVERSE/SYSTEMS/LI04/li04.ini
@@ -6494,6 +6494,17 @@ relief_time = 0
 population_additive = false
 
 [zone]
+nickname = Zone_Li04_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 11500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+population_additive = false
+
+[zone]
 nickname = Zone_Li04_sun_death
 pos = 0, 0, 0
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/LI05/li05.ini
+++ b/DATA/UNIVERSE/SYSTEMS/LI05/li05.ini
@@ -153,10 +153,21 @@ density_restriction = 3, battleship
 density_restriction = 3, cruiser
 
 [zone]
+nickname = Zone_Li05_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 8500
+damage = 250000000
+sort = 99.500000
+density = 0
+relief_time = 0
+population_additive = false
+
+[zone]
 nickname = Zone_Li05_sun_death
 pos = 0, 0, 0
 shape = SPHERE
-size = 9000
+size = 10000
 damage = 250000
 sort = 99.500000
 density = 0

--- a/DATA/UNIVERSE/SYSTEMS/RH01/rh01.ini
+++ b/DATA/UNIVERSE/SYSTEMS/RH01/rh01.ini
@@ -2173,6 +2173,16 @@ visit = 128
 sort = 99.5
 
 [zone]
+nickname = Rh01_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 9500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Rh01_sun_death
 pos = 0, 0, 0
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/RH02/rh02.ini
+++ b/DATA/UNIVERSE/SYSTEMS/RH02/rh02.ini
@@ -1411,6 +1411,16 @@ property_flags = 131072
 sort = 99.5
 
 [zone]
+nickname = Zone_Rh02_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 9500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_Rh02_sun_death
 pos = 0, 0, 0
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/RH03/rh03.ini
+++ b/DATA/UNIVERSE/SYSTEMS/RH03/rh03.ini
@@ -1475,6 +1475,16 @@ loadout = rh_loadout_solar_jumpgate01
 pilot = pilot_solar_ace
 
 [zone]
+nickname = Zone_Rh03_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 9500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_Rh03_sun_death
 pos = 0, 0, 0
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/RH04/rh04.ini
+++ b/DATA/UNIVERSE/SYSTEMS/RH04/rh04.ini
@@ -2586,6 +2586,16 @@ density_restriction = 3, cruiser
 density_restriction = 5, gunboat
 
 [zone]
+nickname = Zone_Rh04_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 8500
+damage = 250000000
+sort = 99.500000
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_Rh04_sun_death
 pos = 0, 0, 0
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/RH05/rh05.ini
+++ b/DATA/UNIVERSE/SYSTEMS/RH05/rh05.ini
@@ -833,6 +833,16 @@ loadout = pi_loadout_solar_base_rock_large_b01
 pilot = pilot_solar_ace
 
 [zone]
+nickname = Zone_Rh05_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 8500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_Rh05_sun_death
 pos = 0, 0, 0
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/ST01/st01.ini
+++ b/DATA/UNIVERSE/SYSTEMS/ST01/st01.ini
@@ -46,8 +46,18 @@ ids_name = 261010
 pos = 0, 0, 0
 Archetype = sun_2000
 star = St03_Sun
-atmosphere_range = 8000
+atmosphere_range = 7000
 ids_info = 66163
+
+[zone]
+nickname = Zone_St01_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 4500
+damage = 250000000
+sort = 99.500000
+density = 0
+relief_time = 0
 
 [zone]
 nickname = Zone_St01_sun_death

--- a/DATA/UNIVERSE/SYSTEMS/ST03/st03.ini
+++ b/DATA/UNIVERSE/SYSTEMS/ST03/st03.ini
@@ -51,10 +51,20 @@ star = St03_Sun
 ids_info = 66163
 
 [zone]
+nickname = Zone_St03_sun_superdeath
+pos = -32480, 12000, -6630
+shape = SPHERE
+size = 5500
+damage = 250000000
+sort = 99.5
+density = 0
+relief_time = 0
+
+[zone]
 nickname = Zone_St03_sun_death
 pos = -32480, 12000, -6630
 shape = SPHERE
-size = 6000
+size = 7000
 damage = 250000
 sort = 99.5
 density = 0

--- a/DATA/UNIVERSE/SYSTEMS/ST03B/st03b.ini
+++ b/DATA/UNIVERSE/SYSTEMS/ST03B/st03b.ini
@@ -58,6 +58,16 @@ star = green_giant_sun
 atmosphere_range = 11000
 
 [zone]
+nickname = Zone_St03b_sun_superdeath
+pos = 0, 0, 0
+shape = SPHERE
+size = 8500
+damage = 250000000
+visit = 128
+sort = 99.5
+population_additive = false
+
+[zone]
 nickname = Zone_St03b_sun_death
 pos = 0, 0, 0
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/START/start.ini
+++ b/DATA/UNIVERSE/SYSTEMS/START/start.ini
@@ -112,6 +112,14 @@ nebulae = solar\starsphere\starsphere_iw04.cmp
 ;SONNEN
 
 [zone]
+nickname = start_Sun1_superdeath
+pos = 6000, 1380, -5520
+shape = SPHERE
+size = 8500
+damage = 250000000
+visit = 128
+
+[zone]
 nickname = start_Sun1_death
 pos = 6000, 1380, -5520
 shape = SPHERE
@@ -137,6 +145,14 @@ color = 100, 180, 100
 range = 90000
 type = DIRECTIONAL
 atten_curve = DYNAMIC_DIRECTION
+
+[zone]
+nickname = start_Sun2_superdeath
+pos = -8000, -1840, 7360
+shape = SPHERE
+size = 6500
+damage = 250000000
+visit = 128
 
 [zone]
 nickname = start_Sun2_death
@@ -166,6 +182,14 @@ type = DIRECTIONAL
 atten_curve = DYNAMIC_DIRECTION
 
 [zone]
+nickname = start_Sun3_superdeath
+pos = -70000, 20000, -110000
+shape = SPHERE
+size = 6500
+damage = 250000000
+visit = 128
+
+[zone]
 nickname = start_Sun3_death
 pos = -70000, 20000, -110000
 shape = SPHERE
@@ -180,7 +204,7 @@ pos = -70000, 20000, -110000
 ambient_color = 100, 170, 200
 archetype = sun_1000
 star = sm_white_sun
-atmosphere_range = 1000
+atmosphere_range = 10000
 burn_color = 100, 170, 200
 ids_info = 66151
 


### PR DESCRIPTION
Updated every system with one or more suns to have an additional, smaller death zone that instantly kills capital ships while keeping the outer death zone damage unchanged.

Added death zone to Omega-41 neutron star.

Cleaned up errors from Vanilla and otherwise to keep behaviours consistent.

Some QOL improvements regarding autopilot pathfinding in Tau-31, Omicron Minor and Sigma-19.

ToDo: A second pass on Hudson (Iw02) to adjust mission vignettes if necessary (exact behaviours not perfectly known yet, similar issues exist in systems like Dublin, postponing this part for a future change)