### PR TITLE
Fixed weapon display name errors

### DIFF
--- a/DATA/EQUIPMENT/weapon_equip.ini
+++ b/DATA/EQUIPMENT/weapon_equip.ini
@@ -30091,6 +30091,7 @@ flash_radius = 15
 light_anim = l_gun01_flash
 projectile_archetype = ku_turret_capital_light01_ammo
 separation_explosion = sever_debris
+hp_gun_type = hp_turret_special_7
 auto_turret = true
 turn_rate = 135
 LODranges = 0, 2000
@@ -36511,7 +36512,7 @@ lootable = true
 nickname = fc_h_turret_plasma_medium01
 ids_name = 459433
 ;res str
-; Rat ($class)
+; Rat Turret
 ids_info = 461373
 ;res html
 ; \m\bHA-06 "Rat" Hogosha Turret\l\B
@@ -37793,7 +37794,7 @@ lootable = true
 nickname = gd_im_turret_tachyon_light01
 ids_name = 459455
 ;res str
-; Matterthief ($class)
+; Matterthief Turret
 ids_info = 461395
 ;res html
 ; \m\bA1-ITC "Matterthief" IMG Turret\l\B
@@ -37839,7 +37840,7 @@ lootable = true
 nickname = gd_im_turret_tachyon_medium01
 ids_name = 459456
 ;res str
-; Vampire ($class)
+; Vampire Turret
 ids_info = 461396
 ;res html
 ; \m\bB1-ITC "Vampire" IMG Turret\l\B


### PR DESCRIPTION
Both the IM and Hogosha turret(s) have the addendum Turret now rather than printing () for a hardpoint type without a class letter, and the Kusari Light Cap Turret has its hardpoint class added properly. 

This appears to have been all of them.