### PR TITLE
Fix weapon display name errors addendum

### DIFF
--- a/DATA/EQUIPMENT/weapon_equip.ini
+++ b/DATA/EQUIPMENT/weapon_equip.ini
@@ -42385,7 +42385,7 @@ ids_name = 459535
 ids_info = 461475
 ;res html
 ; \m\bGK-11 "Skyburst" GMG Weapon\l\B
-;
+; 
 ; Type: $classLong $damageType
 ; Hull/Energy Damage: $hullDamage/$energyDamage
 ; Range: $range m
@@ -42631,7 +42631,7 @@ ids_name = 459539
 ids_info = 461479
 ;res html
 ; \m\bGK-11 "Skyburst" GMG Turret\l\B
-;
+; 
 ; Type: $classLong $damageType
 ; Hull/Energy Damage: $hullDamage/$energyDamage
 ; Range: $range m

--- a/DATA/EQUIPMENT/weapon_equip.ini
+++ b/DATA/EQUIPMENT/weapon_equip.ini
@@ -42315,7 +42315,7 @@ lootable = true
 nickname = fc_c_turret_pulse_heavy01
 ids_name = 459534
 ;res str
-; Tizona del Cid ($class)
+; Tizona del Cid Turret
 ids_info = 461474
 ;res html
 ; \m\b4b-cc "Tizona del Cid" Corsair Turret\l\B


### PR DESCRIPTION
* Fixed the remaining Corsair Trizona pulse turret empty brackets.
* Fixed the Skyburst (L) and Skyburst turret broken infocards broken in last patch.

Confirmed with FLStat and a regex search that no more Turrets with ($class) or missing spaces after ; exist in this file.