### PR TITLE
Fixed an escaped linebreak in Power Unit Light infocard

### DIFF
--- a/DATA/EQUIPMENT/power_equip.ini
+++ b/DATA/EQUIPMENT/power_equip.ini
@@ -473,7 +473,7 @@ ids_info = 460967
 ; 
 ; Type: $classLong
 ; Capacity: $capacity
-; Charge Rate: $chargeRate /s 
+; Charge Rate: $chargeRate /s
 ; Thruster Capacity: $thrustCapacity
 ; Thruster Charge Rate: $thrustChargeRate /s
 ; Mass: $mass


### PR DESCRIPTION
This was the only bug of its kind it seems. The spare space causes the next line to be parsed right behind the charge rate line and wrap around to linebreak, instead of staying as one line per stat.