### PR TITLE
Red hessian wrecks still using bw models instead of pi models #483

### DIFF
--- a/DATA/SOLAR/loadouts_wrecks.ini
+++ b/DATA/SOLAR/loadouts_wrecks.ini
@@ -201,14 +201,13 @@ equip = ge_s_cm_02, HpCM01
 cargo = ge_s_cm_02_ammo, 20
 
 [Loadout]
-nickname = SECRET_rh_bw_elite_rh01
+nickname = SECRET_rh_pi_elite_rh01
 equip = fc_rh_gun_laser_light01, HpWeapon01
 equip = fc_rh_gun_laser_light01, HpWeapon02
-equip = fc_rh_turret_laser_light01, HpTurret01
 equip = cv_shield_graviton_medium_adv01, HpShield01
 
 [Loadout]
-nickname = SECRET_rh_bw_elite_rh03
+nickname = SECRET_rh_pi_elite_rh03
 equip = fc_rh_gun_laser_medium01, HpWeapon01
 equip = fc_rh_gun_laser_medium01, HpWeapon02
 equip = fc_rh_turret01_mark02, HpTurret01
@@ -216,18 +215,19 @@ cargo = commodity_sidearms, 20
 equip = cv_shield_graviton_medium_adv01, HpShield01
 
 [Loadout]
-nickname = SECRET_rh_bw_elite_bw02a
-equip = fc_rh_turret_laser_heavy01, HpTurret01
+nickname = SECRET_rh_pi_elite_bw02a
+equip = fc_rh_gun_laser_light01, HpWeapon01
+equip = fc_rh_gun_laser_light01, HpWeapon02
 equip = cv_shield_graviton_medium_adv01, HpShield01
 
 [Loadout]
-nickname = SECRET_rh_bw_elite_bw02b
-equip = missile_hull_guided_heavy02, HpWeapon01
+nickname = SECRET_rh_pi_elite_bw02b
+equip = fc_rh_gun_particle_medium01, HpWeapon01
 equip = fc_rh_gun_particle_medium01, HpWeapon02
-equip = fc_rh_turret_laser_heavy01, HpTurret01
+equip = missile_hull_guided_heavy02, HpWeapon03
 
 [Loadout]
-nickname = SECRET_rh_bw_elite_bw04
+nickname = SECRET_rh_pi_elite_bw04
 equip = special_gun02, HpWeapon01
 equip = special_gun02, HpWeapon02
 equip = fc_rh_turret01_mark01, HpTurret01
@@ -859,14 +859,6 @@ equip = gd_z_gun_photon_light01, HpWeapon02
 cargo = cv_power_module_charger_adv01, 1
 
 [Loadout]
-nickname = SECRET_Erik_Schulz
-equip = gun_codename_plasma_special03, HpTorpedo01
-equip = fc_rh_gun_laser_heavy01, HpWeapon03
-equip = fc_rh_gun_laser_heavy01, HpWeapon04
-cargo = cv_power_module_charger_adv01, 1
-cargo = cv_thruster_03, 1
-
-[Loadout]
 nickname = SECRET_Twilight_Brigade01
 equip = fc_rh_gun_laser_medium01, HpWeapon01
 equip = fc_rh_gun_laser_medium01, HpWeapon02
@@ -879,6 +871,14 @@ equip = fc_rh_gun_laser_light01, HpWeapon02
 [Loadout]
 nickname = SECRET_Twilight_Brigade03
 equip = fc_rh_gun_laser_heavy02, HpTorpedo01
+
+[Loadout]
+nickname = SECRET_Twilight_Brigade04
+equip = gun_codename_plasma_special03, HpTorpedo01
+equip = fc_rh_gun_laser_heavy01, HpWeapon03
+equip = fc_rh_gun_laser_heavy01, HpWeapon04
+cargo = cv_power_module_charger_adv01, 1
+cargo = cv_thruster_03, 1
 
 [Loadout]
 nickname = SECRET_Junker_Bw08

--- a/DATA/SOLAR/solararch.ini
+++ b/DATA/SOLAR/solararch.ini
@@ -6699,6 +6699,21 @@ fuse = fuse_suprise_drop_loot, 0, 2000
 
 [Solar]
 type = MISSION_SATELLITE
+nickname = suprise_pi_elite2
+LODranges = 0, 600, 1200, 10000
+DA_archetype = Ships\corsair\co_elite2\co_elite2.cmp
+material_library = ships\corsair\co_ships.mat
+surface_hit_effects = 0, small_hull_hit
+mass = 1e10
+solar_radius = 800
+shape_name = NAV_surpriseX
+explosion_arch = explosion_li_elite
+hit_pts = 6000
+destructible = true
+fuse = fuse_suprise_drop_loot, 0, 2000
+
+[Solar]
+type = MISSION_SATELLITE
 nickname = suprise_pi_freighter
 LODranges = 0, 600, 1200, 10000
 DA_archetype = Ships\corsair\co_freighter\co_freighter.cmp

--- a/DATA/UNIVERSE/SYSTEMS/BW02/bw02.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BW02/bw02.ini
@@ -2097,71 +2097,71 @@ visit = 16
 ids_info = 66408
 
 [Object]
-nickname = Bw02_suprise_bw_elite_1
+nickname = Bw02_suprise_pi_elite_1
 ids_name = 261747
 pos = -2853, 0, 4881
-archetype = suprise_bw_elite
+archetype = suprise_pi_elite2
 visit = 16
 ids_info = 66409
 
 [Object]
-nickname = Bw02_suprise_bw_elite_2
+nickname = Bw02_suprise_pi_fighter_2
 ids_name = 261747
 pos = -4224, 0, -2205
-archetype = suprise_bw_elite
+archetype = suprise_pi_fighter
 visit = 16
 ids_info = 66409
 
 [Object]
-nickname = Bw02_suprise_bw_elite_3
+nickname = Bw02_suprise_pi_elite_3
 ids_name = 261747
 pos = 2732, 0, 2222
-archetype = suprise_bw_elite
+archetype = suprise_pi_elite2
 visit = 16
 ids_info = 66409
-loadout = SECRET_rh_bw_elite_bw02b
+loadout = SECRET_rh_pi_elite_bw02b
 
 [Object]
-nickname = Bw02_suprise_bw_elite_4
+nickname = Bw02_suprise_pi_elite_4
 ids_name = 261747
 pos = 3356, -200, 7067
 rotate = 30, 0, 50
-archetype = suprise_bw_elite
+archetype = suprise_pi_elite2
 visit = 16
 ids_info = 66409
 
 [Object]
-nickname = Bw02_suprise_bw_elite_5
+nickname = Bw02_suprise_pi_elite_5
 ids_name = 261747
 pos = 468, 0, 5408
-archetype = suprise_bw_elite
+archetype = suprise_pi_elite2
 visit = 16
 ids_info = 66409
 
 [Object]
-nickname = Bw02_suprise_bw_elite_6
+nickname = Bw02_suprise_pi_elite_6
 ids_name = 261747
 pos = 8049, 0, 10459
-archetype = suprise_bw_elite
+archetype = suprise_pi_elite
 visit = 16
 ids_info = 66409
-loadout = SECRET_rh_bw_elite_bw02a
+loadout = SECRET_rh_pi_elite_bw02a
 
 [Object]
-nickname = Bw02_suprise_bw_elite_7
+nickname = Bw02_suprise_pi_fighter_7
 pos = 6099, 600, 14077
 rotate = 30, 0, 10
-archetype = suprise_bw_elite
+archetype = suprise_pi_fighter
 visit = 16
 ids_name = 261747
 ids_info = 66409
 
 [Object]
-nickname = Bw02_suprise_bw_elite_8
+nickname = Bw02_suprise_pi_elite_8
 ids_name = 261747
 pos = 4511, 0, 7368
 rotate = 50, 30, 0
-archetype = suprise_bw_elite
+archetype = suprise_pi_elite2
 visit = 16
 ids_info = 66409
 
@@ -2200,80 +2200,80 @@ visit = 16
 ids_info = 66408
 
 [Object]
-nickname = Bw02_suprise_bw_elite_9
+nickname = Bw02_suprise_pi_elite_9
 ids_name = 261747
 pos = 3388, 0, 9616
-archetype = suprise_bw_elite
+archetype = suprise_pi_elite
 visit = 16
 ids_info = 66409
 
 [Object]
-nickname = Bw02_suprise_bw_elite_10
+nickname = Bw02_suprise_pi_elite_10
 ids_name = 261747
 pos = 1492, 0, 4528
 rotate = 60, -10, 10
-archetype = suprise_bw_elite
+archetype = suprise_pi_elite2
 visit = 16
 ids_info = 66409
 
 [Object]
-nickname = Bw02_suprise_bw_elite_11
+nickname = Bw02_suprise_pi_elite_11
 ids_name = 261747
 pos = 630, -400, 525
 rotate = 25, 9, 4
-archetype = suprise_bw_elite
+archetype = suprise_pi_elite
 visit = 16
 ids_info = 66409
 
 [Object]
-nickname = Bw02_suprise_bw_elite_12
+nickname = Bw02_suprise_pi_elite_12
 ids_name = 261747
 pos = 2989, 0, -2113
-archetype = suprise_bw_elite
+archetype = suprise_pi_elite2
 visit = 16
 ids_info = 66409
 
 [Object]
-nickname = Bw02_suprise_bw_elite_13
+nickname = Bw02_suprise_pi_elite_13
 ids_name = 261747
 pos = 5044, -200, 236
 rotate = 20, 0, 30
-archetype = suprise_bw_elite
+archetype = suprise_pi_elite
 visit = 16
 ids_info = 66409
 
 [Object]
-nickname = Bw02_suprise_bw_elite_14
+nickname = Bw02_suprise_pi_elite_14
 ids_name = 261747
 pos = 7149, 0, 4779
 rotate = 0, 0, 90
-archetype = suprise_bw_elite
+archetype = suprise_pi_elite2
 visit = 16
 ids_info = 66409
 
 [Object]
-nickname = Bw02_suprise_bw_elite_15
+nickname = Bw02_suprise_pi_elite_15
 ids_name = 261747
 pos = 8936, 0, 5543
-archetype = suprise_bw_elite
+archetype = suprise_pi_elite2
 visit = 16
 ids_info = 66409
 
 ;; Twilight Brigade 
 
 [Object]
-nickname = Bw02_suprise_Erik_Schulz
+nickname = Bw02_suprise_Twilight_Brigade00
 ids_name = 460114
 ;res str
-; Erik Schulz
+; Fighter of the Twilight Brigade
 ids_info = 461866
 ;res html
-; The remains of this ship belonged to a pilot named Erik Schulz; leader of the Twilight Brigade, famous among the Red Hessians. Scans show the Twilight Brigade taking heavy casualties in a major battle against the Corsairs. Erik Schulz died in the process.\n
+; The remains of a ship of the Twilight Brigade, famous among the Red Hessians. The pilot died during a major battle against the Corsairs.\n
 pos = 6290.2257, -307.45695, -18594.9100
 rotate = 30, 50, 20
 Archetype = suprise_pi_elite
 visit = 16
-loadout = SECRET_Erik_Schulz
+loadout = SECRET_Twilight_Brigade04
 
 [Object]
 nickname = Bw02_suprise_Twilight_Brigade01

--- a/DATA/UNIVERSE/SYSTEMS/BW04/bw04.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BW04/bw04.ini
@@ -2642,39 +2642,39 @@ ids_info = 66414
 loadout = SECRET_c_co_elite_bw04
 
 [Object]
-nickname = Bw04_suprise_bw_elite_1
+nickname = Bw04_suprise_pi_elite_1
 ids_name = 261747
 pos = 15031, 0, 6285
 rotate = 50, 40, 45
-archetype = suprise_bw_elite
+archetype = suprise_pi_elite2
 ids_info = 66416
-loadout = SECRET_rh_bw_elite_bw04
+loadout = SECRET_rh_pi_elite_bw04
 visit = 16
 
 [Object]
-nickname = Bw04_suprise_bw_elite_2
+nickname = Bw04_suprise_pi_elite_2
 ids_name = 261747
 pos = -2124, 0, 16243
 rotate = 80, 0, 60
-archetype = suprise_bw_elite
+archetype = suprise_pi_elite2
 visit = 16
 ids_info = 66416
 
 [Object]
-nickname = Bw04_suprise_bw_elite_3
+nickname = Bw04_suprise_pi_elite_3
 ids_name = 261747
 pos = -7267, 0, 13847
 rotate = 40, 50, 23
-archetype = suprise_bw_elite
+archetype = suprise_pi_elite2
 visit = 16
 ids_info = 66416
 
 [Object]
-nickname = Bw04_suprise_bw_elite_4
+nickname = Bw04_suprise_pi_elite_4
 ids_name = 261747
 pos = -13191, 0, 9035
 rotate = 80, 0, 0
-archetype = suprise_bw_elite
+archetype = suprise_pi_elite2
 visit = 16
 ids_info = 66416
 

--- a/DATA/UNIVERSE/SYSTEMS/RH01/rh01.ini
+++ b/DATA/UNIVERSE/SYSTEMS/RH01/rh01.ini
@@ -6758,14 +6758,14 @@ ids_info = 66467
 loadout = SECRET_u_ge_fighter4_rh01
 
 [Object]
-nickname = Rh01_suprise_bw_elite_1
+nickname = Rh01_suprise_pi_elite_1
 ids_name = 261747
 pos = -39211, 0, -43394
 rotate = 20, -65, 90
-Archetype = suprise_bw_elite
+Archetype = suprise_pi_elite2
 visit = 16
 ids_info = 66466
-loadout = SECRET_rh_bw_elite_rh01
+loadout = SECRET_rh_pi_elite_rh01
 
 [zone]
 nickname = ZONE_Rh01_vignette14_exclusion

--- a/DATA/UNIVERSE/SYSTEMS/RH03/rh03.ini
+++ b/DATA/UNIVERSE/SYSTEMS/RH03/rh03.ini
@@ -3439,14 +3439,14 @@ ids_info = 66468
 loadout = SECRET_armored_rh03
 
 [Object]
-nickname = Rh03_suprise_bw_elite_1
+nickname = Rh03_suprise_pi_elite_1
 ids_name = 261736
 pos = -51484, 0, 52389
 rotate = -56, 61, 118
-archetype = suprise_bw_elite
+archetype = suprise_pi_elite
 visit = 16
 ids_info = 66470
-loadout = SECRET_rh_bw_elite_rh03
+loadout = SECRET_rh_pi_elite_rh03
 
 [Object]
 nickname = Rh03_suprise_transport_1


### PR DESCRIPTION
- Added Foxhound wreckage in Solarach for fitting Red Hessian wreckages
- Renamed all Red Hessian "BW" nicknames and loadout designations to "PI"

I have taken the liberty to fix some lore technical as well as appearance issues like mixing the models in the Omega-5 battlefield and replacing the ship of the still living leader of the Red Hessian twilight brigade with just another member of it but keeping its loadout (also renamed the nickname of the Erik Schultz loadout) 