### PR TITLE
Fixing wrong position of Helium³ Gas-Pockets in IW06

### DIFF
--- a/DATA/UNIVERSE/SYSTEMS/IW06/iw06.ini
+++ b/DATA/UNIVERSE/SYSTEMS/IW06/iw06.ini
@@ -799,7 +799,7 @@ ids_info = 462193
 ; \m\bHelium³ Gas Pocket\l\B
 ; 
 ; A and dense gaseous mass of helium³, it is a rare element and a very valuable source of energy, can only be harvested with the appropriate equipment.
-pos = 33123.1137, 0.2621, 23167.4450
+pos = -3854.6771, 0.2621, 20554.8877
 archetype = mineable_gas_pocket
 loadout = mineable_gas_small_helium3
 
@@ -813,7 +813,7 @@ ids_info = 462194
 ; \m\bHelium³ Gas Pocket\l\B
 ; 
 ; A and dense gaseous mass of helium³, it is a rare element and a very valuable source of energy, can only be harvested with the appropriate equipment.
-pos = 8795.0553, 1022.8284, 23588.0034
+pos = -3438.9191, 106.9752, 20226.4158
 archetype = mineable_gas_pocket
 loadout = mineable_gas_small_helium3
 


### PR DESCRIPTION
Moving Helium³ Gas Pockets back in to the Raiden Cloud