### PR TITLE
Changing Freighter Weapons Slot for adding a Minin Device Slot

### DIFF
--- a/DATA/SHIPS/shiparch.ini
+++ b/DATA/SHIPS/shiparch.ini
@@ -1049,7 +1049,7 @@ ids_info = 461632
 ; Batteries/Nanobots: $shieldBatteries/$nanobots
 ; 
 ; \bWeapon Mounts\B
-; Guns/Launchers: 2 M
+; Guns/Launchers: 2 M, 1 Miner
 ; Turrets: 1
 ; Droppers: 1 CM
 ; 
@@ -1072,7 +1072,7 @@ ids_info3 = 461633
 ; $shieldBatteries/$nanobots
 ; 
 ; 
-; 2 M
+; 2 M, 1 Miner
 ; 1
 ; 1 CM
 ; 
@@ -1523,7 +1523,7 @@ ids_info = 461638
 ; Batteries/Nanobots: -
 ; 
 ; \bWeapon Mounts\B
-; Guns/Launchers: 1 X
+; Guns/Launchers: 1 Miner
 ; Turrets: 6 M, 4 H
 ; Droppers: -
 ; 
@@ -1546,7 +1546,7 @@ ids_info3 = 461639
 ; -
 ; 
 ; 
-; 1 X
+; 1 Miner
 ; 6 M, 4 H
 ; -
 ; 
@@ -2269,12 +2269,12 @@ ids_info = 461646
 ; Batteries/Nanobots: $shieldBatteries/$nanobots
 ; 
 ; \bWeapon Mounts\B
-; Guns/Launchers: 2 M, 1 H
+; Guns/Launchers: 2 H, 1 Miner
 ; Turrets: 6
 ; Droppers: 1 Mine, 1 CM
 ; 
 ; \bExternal Mounts\B
-; Shields: -
+; Shields: 1 X
 ; Thrusters: -
 ; 
 ; \bInternal Mounts\B
@@ -2292,7 +2292,7 @@ ids_info3 = 461647
 ; $shieldBatteries/$nanobots
 ; 
 ; 
-; 2 M, 1 H
+; 2 H, 1 Miner
 ; 6
 ; 1 Mine, 1 CM
 ; 
@@ -2349,8 +2349,8 @@ strafe_power_usage = 80
 nanobot_limit = 50
 shield_battery_limit = 20
 shield_link = ge_armored_shield01, HpMount, HpShield01
-hp_type = hp_gun_special_3, HpTurret07
-hp_type = hp_gun_special_2, HpTurret05, HpTurret06
+hp_type = hp_gun_special_5, HpTurret07
+hp_type = hp_gun_special_3, HpTurret05, HpTurret06
 hp_type = hp_turret_special_1, HpTurret01, HpTurret02, HpTurret03, HpTurret04, HpTurret08, HpTurret09
 hp_type = hp_freighter_shield_special_1, HpShield01
 hp_type = hp_mine_dropper, HpMine01
@@ -3863,7 +3863,7 @@ ids_info = 461670
 ; Batteries/Nanobots: $shieldBatteries/$nanobots
 ; 
 ; \bWeapon Mounts\B
-; Guns/Launchers: 2 M, 1 H
+; Guns/Launchers: 2 H, 1 Miner
 ; Turrets: 5
 ; Droppers: 1 Mine, 1 CM
 ; 
@@ -3886,7 +3886,7 @@ ids_info3 = 461671
 ; $shieldBatteries/$nanobots
 ; 
 ; 
-; 2 M, 1 H
+; 2 H, 1 Miner
 ; 5
 ; 1 Mine, 1 CM
 ; 
@@ -3944,8 +3944,8 @@ HP_bay_external = HpBayDoor02
 HP_tractor_source = HpTractor_Source
 num_exhaust_nozzles = 2
 shield_link = l_freighter_shield01, HpMount, HpShield01
-hp_type = hp_gun_special_3, HpWeapon01
-hp_type = hp_gun_special_2, HpWeapon02, HpWeapon03
+hp_type = hp_gun_special_5, HpWeapon01
+hp_type = hp_gun_special_3, HpWeapon02, HpWeapon03
 hp_type = hp_turret_special_1, HpTurret01, HpTurret02, HpTurret03, HpTurret04, HpTurret05
 hp_type = hp_freighter_shield_special_1, HpShield01
 hp_type = hp_thruster, HpThruster01
@@ -5315,7 +5315,7 @@ ids_info = 461686
 ; Batteries/Nanobots: $shieldBatteries/$nanobots
 ; 
 ; \bWeapon Mounts\B
-; Guns/Launchers: 2 M, 1 H
+; Guns/Launchers: 2 H, 1 Miner
 ; Turrets: 5
 ; Droppers: 1 Mine, 1 CM
 ; 
@@ -5338,7 +5338,7 @@ ids_info3 = 461687
 ; $shieldBatteries/$nanobots
 ; 
 ; 
-; 2 M, 1 H
+; 2 H, 1 Miner
 ; 5
 ; 1 Mine, 1 CM
 ; 
@@ -5396,8 +5396,8 @@ HP_bay_external = HpBayDoor02
 HP_tractor_source = HpTractor_Source
 num_exhaust_nozzles = 2
 shield_link = b_freighter_shield01, HpMount, HpShield01
-hp_type = hp_gun_special_3, HpWeapon01
-hp_type = hp_gun_special_2, HpWeapon02, HpWeapon03
+hp_type = hp_gun_special_5, HpWeapon01
+hp_type = hp_gun_special_3, HpWeapon02, HpWeapon03
 hp_type = hp_freighter_shield_special_1, HpShield01
 hp_type = hp_thruster, HpThruster01
 hp_type = hp_mine_dropper, HpMine01
@@ -6634,7 +6634,7 @@ ids_info = 461701
 ; Batteries/Nanobots: $shieldBatteries/$nanobots
 ; 
 ; \bWeapon Mounts\B
-; Guns/Launchers: 2 M, 1 H
+; Guns/Launchers: 2 H, 1 Miner
 ; Turrets: 5
 ; Droppers: 1 Mine, 1 CM
 ; 
@@ -6657,7 +6657,7 @@ ids_info3 = 461702
 ; $shieldBatteries/$nanobots
 ; 
 ; 
-; 2 M, 1 H
+; 2 H, 1 Miner
 ; 5
 ; 1 Mine, 1 CM
 ; 
@@ -6715,8 +6715,8 @@ HP_bay_external = HpBayDoor02
 HP_tractor_source = HpTractor_Source
 num_exhaust_nozzles = 2
 shield_link = k_freighter_shield01, HpMount, HpShield01
-hp_type = hp_gun_special_3, HpTurret06
-hp_type = hp_gun_special_2, HpWeapon01, HpWeapon02
+hp_type = hp_gun_special_5, HpTurret06
+hp_type = hp_gun_special_3, HpWeapon01, HpWeapon02
 hp_type = hp_freighter_shield_special_1, HpShield01
 hp_type = hp_thruster, HpThruster01
 hp_type = hp_mine_dropper, HpMine01
@@ -8023,7 +8023,7 @@ ids_info = 461716
 ; Batteries/Nanobots: $shieldBatteries/$nanobots
 ; 
 ; \bWeapon Mounts\B
-; Guns/Launchers: 2 M, 1 H
+; Guns/Launchers: 2 H, 1 Miner
 ; Turrets: 5
 ; Droppers: 1 Mine, 1 CM
 ; 
@@ -8046,7 +8046,7 @@ ids_info3 = 461717
 ; $shieldBatteries/$nanobots
 ; 
 ; 
-; 2 M, 1 H
+; 2 H, 1 Miner
 ; 5
 ; 1 Mine, 1 CM
 ; 
@@ -8104,8 +8104,8 @@ HP_bay_external = HpBayDoor02
 HP_tractor_source = HpTractor_Source
 num_exhaust_nozzles = 2
 shield_link = r_freighter_shield01, HpMount, HpShield01
-hp_type = hp_gun_special_3, HpTurret05
-hp_type = hp_gun_special_2, HpWeapon01, HpWeapon02
+hp_type = hp_gun_special_5, HpTurret05
+hp_type = hp_gun_special_3, HpWeapon01, HpWeapon02
 hp_type = hp_freighter_shield_special_1, HpShield01
 hp_type = hp_thruster, HpThruster01
 hp_type = hp_mine_dropper, HpMine01
@@ -8193,7 +8193,7 @@ ids_info3 = 461719
 ; -
 ; 
 ; 
-; 1X
+; 1 X
 ; 5 L, 1 M
 ; 1 Mine, 1 CM
 ; 
@@ -10277,7 +10277,7 @@ ids_info = 461743
 ; Batteries/Nanobots: $shieldBatteries/$nanobots
 ; 
 ; \bWeapon Mounts\B
-; Guns/Launchers: 2 M, 1 H
+; Guns/Launchers: 2 H, 1 Miner
 ; Turrets: 5
 ; Droppers: 1 Mine, 1 CM
 ; 
@@ -10300,7 +10300,7 @@ ids_info3 = 461744
 ; $shieldBatteries/$nanobots
 ; 
 ; 
-; 2 M, 1 H
+; 2 H, 1 Miner
 ; 5
 ; 1 Mine, 1 CM
 ; 
@@ -10358,8 +10358,8 @@ HP_bay_external = HpBayDoor02
 HP_tractor_source = HpTractor_Source
 num_exhaust_nozzles = 3
 shield_link = bw_freighter_shield01, HpMount, HpShield01
-hp_type = hp_gun_special_3, HpWeapon01
-hp_type = hp_gun_special_2, HpWeapon02, HpWeapon03
+hp_type = hp_gun_special_5, HpWeapon01
+hp_type = hp_gun_special_3, HpWeapon02, HpWeapon03
 hp_type = hp_freighter_shield_special_1, HpShield01
 hp_type = hp_thruster, HpThruster01
 hp_type = hp_mine_dropper, HpMine01
@@ -11940,8 +11940,8 @@ ids_info = 461765
 ; Batteries/Nanobots: $shieldBatteries/$nanobots
 ; 
 ; \bWeapon Mounts\B
-; Guns/Launchers: 2 M, 2 H
-; Turrets: 4
+; Guns/Launchers: 2 M, 2 H, 1 Miner
+; Turrets: 3
 ; Droppers: 1 Mine, 1 CM
 ; 
 ; \bExternal Mounts\B
@@ -11963,8 +11963,8 @@ ids_info3 = 461766
 ; $shieldBatteries/$nanobots
 ; 
 ; 
-; 2 M, 2 H
-; 4
+; 2 M, 2 H, 1 Miner
+; 3
 ; 1 Mine, 1 CM
 ; 
 ; 
@@ -12021,13 +12021,14 @@ HP_bay_external = HpBayDoor02
 HP_tractor_source = HpTractor_Source
 num_exhaust_nozzles = 2
 shield_link = pi_freighter_shield01, HpMount, HpShield01
+hp_type = hp_gun_special_5, HpTurret01
 hp_type = hp_gun_special_3, HpWeapon03, HpWeapon04
 hp_type = hp_gun_special_2, HpWeapon01, HpWeapon02
 hp_type = hp_freighter_shield_special_1, HpShield01
 hp_type = hp_thruster, HpThruster01
 hp_type = hp_mine_dropper, HpMine01
 hp_type = hp_countermeasure_dropper, HpCM01
-hp_type = hp_turret_special_1, HpTurret01, HpTurret02, HpTurret03, HpTurret04
+hp_type = hp_turret_special_1, HpTurret02, HpTurret03, HpTurret04
 hp_type = hp_freighter_engine_special_1, HpEngine01
 hp_type = hp_fighter_power_special_4, DpPortengine
 hp_type = hp_elite_power_special_1, HpModule02


### PR DESCRIPTION
All Freighter Medium Slots are changed to Heavy Slots

Exception: Mule

Mining Device Added on following Slots:

Rhino: HpWeapon01
Clydestale: HpWeapon01
Humpback: HpTurret05
Drone: HpTurret06
Mule: HpTurret01
Dromedary: HpWeapon01

Armored Transport: HpTurret07