### PR TITLE
Update bw09.ini

### DIFF
--- a/DATA/UNIVERSE/SYSTEMS/BW09/bw09.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BW09/bw09.ini
@@ -1425,7 +1425,8 @@ archetype = mineable_gas_pocket
 loadout = mineable_gas_small_oxygen
 
 [Object]
-nickname = 460354
+nickname = mineable_small_oxygen_Bw09_17
+ids_name = 460354
 ;res str
 ; Oxygen Gas Pocket
 ids_info = 462098


### PR DESCRIPTION
Wrong nickname returning "unknown object" mineable object Tau29, Tau23 Jumphole field

nickname = mineable_small_oxygen_Bw09_17, wrong nickname ids_name = 460354