### PR TITLE
Correction of Roid miner loadouts Dresden

### DIFF
--- a/DATA/UNIVERSE/SYSTEMS/RH05/rh05.ini
+++ b/DATA/UNIVERSE/SYSTEMS/RH05/rh05.ini
@@ -1164,7 +1164,7 @@ reputation = co_khc_grp
 dock_with = co_khc_copper_miner
 base = co_khc_copper_miner
 difficulty_level = 13
-loadout = cv_loadout_solar_miner01_cobalt
+loadout = cv_loadout_solar_miner01_copper
 pilot = pilot_solar_ace
 behavior = NOTHING
 
@@ -1179,7 +1179,7 @@ reputation = co_khc_grp
 dock_with = co_khc_copper_miner
 base = co_khc_copper_miner
 difficulty_level = 13
-loadout = cv_loadout_solar_miner01_cobalt
+loadout = cv_loadout_solar_miner01_copper
 pilot = pilot_solar_ace
 behavior = NOTHING
 


### PR DESCRIPTION
Roid miner 6 & 7 carrying Cobalt in a copper zone. Loadout changed to copper.