### PR TITLE
Fix: moved wreck out of asteroid in Omega 5

### DIFF
--- a/DATA/UNIVERSE/SYSTEMS/BW02/bw02.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BW02/bw02.ini
@@ -2311,7 +2311,7 @@ ids_name = 460173
 ids_info = 461969
 ;res html
 ; The remains of a ship of the Twilight Brigade, famous among the Red Hessians. The pilot died during a major battle against the Corsairs.\n
-pos = 15071.6501, -441.9021, -15409.0208
+pos = 15121.6501, -441.9021, -15495.0208
 rotate = 60, 30, 50
 Archetype = suprise_pi_elite
 visit = 16


### PR DESCRIPTION
Tackles: https://discord.com/channels/672893425108123707/1265290039932227604

Twilight Brigade wreck with the Codename weapon is away from the other bunch and not inside an exclusion zone, so upon resizing the asteroids it ended up inside a large asteroid.

Also checked that no other weapons platform or wreck in the system has the same issue.