### PR TITLE
Wrong drop behaviour for some wreckages including named guns #899

### DIFF
--- a/DATA/SOLAR/loadouts.ini
+++ b/DATA/SOLAR/loadouts.ini
@@ -1364,7 +1364,7 @@ cargo = commodity_superconductors, 14, HpCargo04
 nickname = surprise_superconductors
 equip = cargopod_green, HpCargo04
 cargo = commodity_superconductors, 40, HpCargo04
-cargo = special_gun15, 2, HpCargo04
+cargo = blueprint_special_gun15, 2, HpCargo04
 
 [Loadout]
 nickname = depot_optical_chips

--- a/DATA/SOLAR/loadouts_wrecks.ini
+++ b/DATA/SOLAR/loadouts_wrecks.ini
@@ -867,7 +867,7 @@ equip = cv_turret_laser_medium01, HpTurret06
 equip = cv_turret_laser_medium01, HpTurret07
 equip = cv_turret_laser_medium01, HpTurret08
 equip = cv_turret_laser_medium01, HpTurret09
-cargo = special_gun09, 2
+cargo = blueprint_special_gun09, 2
 cargo = commodity_silver, 5
 cargo = cv_turret_laser_medium01, 9
 
@@ -982,13 +982,12 @@ cargo = cv_turret_utility_medium01, 2
 nickname = SECRET_ozu
 equip = ozu_gun_laser_light01, HpWeapon01
 equip = ozu_gun_laser_light01, HpWeapon02
-equip = ozu_gun_laser_light01, HpWeapon03
-equip = ozu_gun_laser_light01, HpWeapon04
 equip = missile_hull_guided_light03, HpWeapon05
-equip = missile_hull_guided_light03, HpWeapon06
 cargo = missile_hull_guided_light03_ammo, 20
 equip = bd_shield_neutrino_medium_opt01, HpShield01
 cargo = ozu_engine_fighter_heavy01, 1
+cargo = ozu_gun_laser_light01, 2
+cargo = missile_hull_guided_light03, 1
 cargo = cv_power_module_charger_adv01, 1
 
 [Loadout]
@@ -1022,6 +1021,7 @@ equip = botzler_gun_tachyon_medium01, HpWeapon03
 equip = botzler_gun_tachyon_medium01, HpWeapon04
 cargo = cv_power_module_charger_std01, 1
 cargo = botzler_engine_fighter_heavy01, 1
+cargo = botzler_gun_tachyon_medium01, 2
 cargo = rh_gun_tachyon_light01, 2
 
 [Loadout]

--- a/DATA/SOLAR/loadouts_wrecks.ini
+++ b/DATA/SOLAR/loadouts_wrecks.ini
@@ -743,15 +743,15 @@ cargo = gd_gm_gun_neutron_heavy01, 2
 [Loadout]
 nickname = SECRET_transport_li04
 equip = cv_turret_utility_light01, HpTurret_U1_01
-equip = special_gun19, HpTurret_U1_02
-equip = special_gun19, HpTurret_U1_03
+equip = cv_turret_utility_light01, HpTurret_U1_02
+equip = cv_turret_utility_light01, HpTurret_U1_03
 equip = cv_turret_utility_light01, HpTurret_U1_04
 equip = cv_turret_utility_medium01, HpTurret_U3_01
 equip = cargopod_blue, hpcargo01
 equip = cargopod_blue, hpcargo02
 cargo = commodity_tradelane_parts, 10, hpcargo01
 cargo = commodity_tradelane_parts, 10, hpcargo02
-cargo = cv_turret_utility_light01, 2
+cargo = blueprint_special_gun19, 2
 cargo = cv_turret_utility_medium01, 1
 
 [Loadout]

--- a/DATA/SOLAR/solararch.ini
+++ b/DATA/SOLAR/solararch.ini
@@ -9970,7 +9970,7 @@ shape_name = NAV_surpriseX
 explosion_arch = explosion_ku_elite
 hit_pts = 8000
 destructible = true
-fuse = fuse_suprise_drop_loot, 0, 2000
+fuse = fuse_suprise_no_loot, 0, 2000
 
 [Solar]
 type = MISSION_SATELLITE
@@ -9985,7 +9985,7 @@ shape_name = NAV_surpriseX
 explosion_arch = explosion_rh_elite
 hit_pts = 8000
 destructible = true
-fuse = fuse_suprise_drop_loot, 0, 2000
+fuse = fuse_suprise_no_loot, 0, 2000
 
 [Solar]
 type = MISSION_SATELLITE


### PR DESCRIPTION
- Fixing Wrong Items dropping from wreckages (Codename dropped directly instead of a Blueprint)
- Named Equipment can now be looted multiple times like any other equipment on wreckages