### PR TITLE
Headsup dangerous zones

### DIFF
--- a/DATA/UNIVERSE/SYSTEMS/BR02/br02.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BR02/br02.ini
@@ -733,6 +733,14 @@ sort = 99.5
 Music = zone_field_mine
 
 [zone]
+nickname = Zone_Br02_Newgate_minefield_headsup
+pos = 3681, 0, 30803
+shape = SPHERE
+size = 6000
+property_flags = 4128
+visit = 128
+
+[zone]
 nickname = Zone_Br02_Exclusion_001
 pos = 4934, 0, 28526
 rotate = 0, -30, 0

--- a/DATA/UNIVERSE/SYSTEMS/BR06/br06.ini
+++ b/DATA/UNIVERSE/SYSTEMS/BR06/br06.ini
@@ -729,6 +729,14 @@ density_restriction = 0, unlawfuls
 Music = zone_field_mine
 
 [zone]
+nickname = Zone_Br06_Scapa_Flow_minefield_headsup
+pos = -27200, -60, 15000
+shape = ELLIPSOID
+size = 10000, 8500, 11000
+property_flags = 4128
+visit = 128
+
+[zone]
 nickname = Zone_Br06_06_mine_exclusion
 pos = -27200, -60, 15000
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/HI01/hi01.ini
+++ b/DATA/UNIVERSE/SYSTEMS/HI01/hi01.ini
@@ -1049,6 +1049,13 @@ loadout = SECRET_bh_bh_elite2_hi01
 
 [zone]
 nickname = Zone_Hi01_outcast_burial_grounds
+ids_name = 460634
+; res str 
+; Sacred Outcast Burial Grounds
+;res str
+; Sacred Outcast Burial Grounds
+;res str
+; the Sacred Outcast Burial Grounds
 pos = 27325, 0, -7711
 shape = SPHERE
 size = 6000

--- a/DATA/UNIVERSE/SYSTEMS/HI02/hi02.ini
+++ b/DATA/UNIVERSE/SYSTEMS/HI02/hi02.ini
@@ -1708,6 +1708,13 @@ loadout = SECRET_bh_bh_elite2_Hi02
 
 [zone]
 nickname = Zone_Hi02_Malvada_graveyard
+ids_name = 460634
+; res str 
+; Graveyard of the Innocents
+;res str
+; Graveyard of the Innocents
+;res str
+; the Graveyard of the Innocents
 pos = 24406, 0, -43335
 shape = SPHERE
 size = 6000

--- a/DATA/UNIVERSE/SYSTEMS/KU04/ku04.ini
+++ b/DATA/UNIVERSE/SYSTEMS/KU04/ku04.ini
@@ -520,6 +520,14 @@ density = 0
 relief_time = 0
 
 [zone]
+nickname = Zone_Ku04_Kansai_mine_field_headsup
+pos = -59207, 0, -58165
+shape = SPHERE
+size = 6000
+property_flags = 4128
+visit = 128
+
+[zone]
 nickname = Zone_Ku04_04_exclusion
 pos = -59248, -1000, -58470
 shape = SPHERE

--- a/DATA/UNIVERSE/SYSTEMS/LI01/li01.ini
+++ b/DATA/UNIVERSE/SYSTEMS/LI01/li01.ini
@@ -1343,6 +1343,14 @@ visit = 32
 sort = 99
 
 [zone]
+nickname = Zone_Li01_zone21_headsup
+pos = 79980, 0, 12470
+shape = ELLIPSOID
+size = 10000, 8500, 10000
+property_flags = 4128
+visit = 128
+
+[zone]
 nickname = Zone_Li01_Badlands_Nebula
 ids_name = 261208
 pos = -7460, 0, 63000

--- a/DATA/UNIVERSE/SYSTEMS/LI05/li05.ini
+++ b/DATA/UNIVERSE/SYSTEMS/LI05/li05.ini
@@ -1055,6 +1055,14 @@ property_flags = 4128
 visit = 32
 Music = zone_nebula_nomad
 
+[zone]
+nickname = Zone_Li05_daam-kovosh_satellite_minefield_headsup
+pos = 44000, 0, 15000
+shape = SPHERE
+size = 8000
+property_flags = 4128
+visit = 128
+
 [Zone]
 nickname = Zone_Li05_daam-kovosh_satellite_death
 pos = 44000, 0, 15000

--- a/DATA/UNIVERSE/SYSTEMS/RH04/rh04.ini
+++ b/DATA/UNIVERSE/SYSTEMS/RH04/rh04.ini
@@ -1262,6 +1262,14 @@ sort = 40
 Music = zone_nebula_nomad
 density_restriction = 0, unlawfuls
 
+[zone]
+nickname = Zone_Rh04_minefield_headsup
+pos = -34000, 0, -55600
+shape = ELLIPSOID
+size = 13000, 9000, 13000
+property_flags = 4128
+visit = 128
+
 ;SHIPYARD BUOYS
 
 [Object]


### PR DESCRIPTION
Dense minefields (which instantly kill you) now give the audio warning once you come within 2K range of the zone already, just like the ones in St03 already do. Solves https://github.com/Freelancer-Sirius-Revival/FLSR/issues/683

The Outcast and Corsair Graveyards in Alpha and Gamma now display their names to the player when they enter them like similar named zones do.