### PR TITLE
Adjusting Halloween Drop Rates (More Pumpkins than Blueprints)

### DIFF
--- a/EXE/flhook_plugins/FLSR-LootBoxes.cfg
+++ b/EXE/flhook_plugins/FLSR-LootBoxes.cfg
@@ -120,8 +120,8 @@ loot_item = fc_or_gun_laser_heavy01, 5.2
 
 [LootBox]
 box_nickname = surprise_box_event_halloween01
-loot_item = material_halloween_pumpkin, 80
-loot_item = blueprint_halloween_br_gun_tachyon_light01, 7.5
-loot_item = blueprint_halloween_br_gun_tachyon_medium01, 7.5
-loot_item = blueprint_halloween_engine_fighter_light01, 2.5
-loot_item = blueprint_halloween_engine_fighter_heavy01, 2.5
+loot_item = material_halloween_pumpkin, 95
+loot_item = blueprint_halloween_br_gun_tachyon_light01, 1.5
+loot_item = blueprint_halloween_br_gun_tachyon_medium01, 1.5
+loot_item = blueprint_halloween_engine_fighter_light01, 1.0
+loot_item = blueprint_halloween_engine_fighter_heavy01, 1.0


### PR DESCRIPTION
Adjusting Droprates for Halloween Trick or Treat Buckets:

- Pumpkin (80% -> 95%)
- Blueprints Guns (7,5% -> 1,5%)
- Blueprints Engines (2,5% -> 1%)

Reason: People storing to many Blueprints