### PR TITLE
Changing ww engine to dropped from box

### DIFF
--- a/Freelancer/DATA/EQUIPMENT/commodity_equip.ini
+++ b/Freelancer/DATA/EQUIPMENT/commodity_equip.ini
@@ -4446,6 +4446,7 @@ ids_info = 460641
 ; \
 ; \bMay contain one of the listed items\B
 ; • Beast Equipment
+; • Wardens Transport or Train Engine
 ; • Sunslayer Torpedo Launcher (very low chance)
 ; \
 ; \cRed\i\bHappy Holidays! - You were naughty!\B\I\C

--- a/Freelancer/DATA/SHIPS/loadouts_co.ini
+++ b/Freelancer/DATA/SHIPS/loadouts_co.ini
@@ -3718,7 +3718,6 @@ equip = cargopod_white, HpCargo01
 equip = cargopod_white, HpCargo02
 cargo = material_christmas_snowball, 50, HpCargo01
 cargo = material_christmas_snowball, 50, HpCargo02
-cargo = gd_ww_engine_transport01, 1
 
 [Loadout]
 nickname = gd_ww_small_train_loadout_d6
@@ -3760,4 +3759,3 @@ cargo = material_christmas_snowball, 50, HpCargo01
 cargo = material_christmas_snowball, 50, HpCargo02
 cargo = material_christmas_snowball, 50, HpCargo03
 cargo = material_christmas_snowball, 50, HpCargo04
-cargo = gd_ww_engine_train01, 1

--- a/Freelancer/EXE/flhook_plugins/FLSR-LootBoxes.cfg
+++ b/Freelancer/EXE/flhook_plugins/FLSR-LootBoxes.cfg
@@ -137,12 +137,15 @@ loot_item = blueprint_christmas_engine_train01, 1.25
 
 [LootBox]
 box_nickname = surprise_box_event_christmas02
-loot_item = fc_gb_gun_laser_light02, 2.5
-loot_item = fc_gb_gun_laser_medium02, 1.25
-loot_item = fc_gb_gun_plasma_heavy02, 1.25
-loot_item = gb_engine_fighter_light01, 2.5
-loot_item = gb_engine_fighter_heavy01, 2.25
+loot_item = fc_gb_gun_laser_light02, 1.45
+loot_item = fc_gb_gun_laser_medium02, 1.45
+loot_item = fc_gb_gun_plasma_heavy02, 1.45
+loot_item = gd_ww_engine_transport01, 1.25
+loot_item = gd_ww_engine_train01, 1.25
+loot_item = gb_engine_fighter_light01, 1.45
+loot_item = gb_engine_fighter_heavy01, 1.45
 loot_item = torpedo01_mark02, 0.25
+
 
 ;; ---------------------
 ;; NAMED BOXES


### PR DESCRIPTION
Removing Transport and Train Engines Drops from WW Transport and Trains because they drop all the time because of the standard Explosion Fuse.  

Moved both Engines to the Naughty Box