### PR TITLE
Changing Sabre for Eagle on FP9

### DIFF
--- a/Freelancer/DATA/EQUIPMENT/market_ships.ini
+++ b/Freelancer/DATA/EQUIPMENT/market_ships.ini
@@ -118,7 +118,7 @@ marketgood = package_bw_elite, 0, 0.4, 1, 1, 0, 1, 1
 
 [BaseGood]
 base = Ew04_01_base
-marketgood = package_bw_elite2, 0, 0.6, 1, 1, 0, 1, 1
+marketgood = package_ge_fighter6, 0, 0.6, 1, 1, 0, 1, 1
 
 [BaseGood]
 base = Hi01_01_base


### PR DESCRIPTION
We have 2 Sabres sold on Freeports (10 & 9)

We should go back to the root to offer Civilian and BW ships across all Freeports, that's why back to vanilla - Eagle on FP9 