### PR TITLE
Fix summer & autumn freighter engines crafting recipes

### DIFF
--- a/Freelancer/EXE/flhook_plugins/FLSR-Crafting.cfg
+++ b/Freelancer/EXE/flhook_plugins/FLSR-Crafting.cfg
@@ -1153,7 +1153,7 @@ product = event_summer_engine_freighter01, 1
 ingredient = blueprint_summer_engine_freighter01, 1
 ingredient = fc_gb_gun_laser_light02, 2
 ingredient = fc_gb_gun_laser_medium02, 2
-ingredient = fc_gb_gun_plasma_heavy02, 2
+ingredient = gb_engine_fighter_heavy01, 2
 cost = 0
 success_sound_nickname = Crafting_successful_equipment
 
@@ -1192,7 +1192,7 @@ product = event_autumn_engine_freighter01, 1
 ingredient = blueprint_autumn_engine_freighter01, 1
 ingredient = fc_gb_gun_laser_light02, 2
 ingredient = fc_gb_gun_laser_medium02, 2
-ingredient = fc_gb_gun_plasma_heavy02, 2
+ingredient = gb_engine_fighter_heavy01, 2
 cost = 0
 success_sound_nickname = Crafting_successful_equipment
 


### PR DESCRIPTION
Fixes a mismatch between tooltip and actual recipe of the last two seasonal Freighter engines.

This change has also already been applied to live server as a hotfix.