### PR TITLE
Fix missing object names for Bw10 loot solars

### DIFF
--- a/Freelancer/EXE/flhook_plugins/missions/Christmas_Event.ini
+++ b/Freelancer/EXE/flhook_plugins/missions/Christmas_Event.ini
@@ -190,6 +190,7 @@ pilot = pilot_solar_wardens_ace
 ; Wardens Snowball Vaults Tau-31
 [MsnSolar]
 nickname = mineable_large_ice_bw10_Wardens01
+string_id = 261161
 archetype = ast_ice_small01_ice_wardens01_mineable
 position = -31370.0, 0, -39260.0
 rotate = 220.0, 71.0, 55.0
@@ -199,6 +200,7 @@ loadout = ast_ice_small01_mineable_wardens01_load
 
 [MsnSolar]
 nickname = mineable_large_ice_bw10_Wardens02
+string_id = 261161
 archetype = ast_ice_small01_ice_wardens01_mineable
 position = -34335.0, 0, -36250.0
 rotate = 220.0, 71.0, 55.0
@@ -208,6 +210,7 @@ loadout = ast_ice_small01_mineable_wardens01_load
 
 [MsnSolar]
 nickname = mineable_large_ice_bw10_Wardens03
+string_id = 261161
 archetype = ast_ice_small01_ice_wardens01_mineable
 position = -34350.0, 0, -39210.0
 rotate = 220.0, 71.0, 55.0


### PR DESCRIPTION
Already hotfixed on Live server script as well