### PR TITLE
CI: updated

### DIFF
--- a/.github/workflows/refresh_dev_version.yml
+++ b/.github/workflows/refresh_dev_version.yml
@@ -1,15 +1,18 @@
-name: Test
+name: Publish Dev version
 
 on:
   push:
     branches: [ main ]
-  pull_request: {}
   workflow_dispatch: {}
 
 jobs:
   test:
     name: test
     runs-on: ubuntu-22.04
+    permissions:
+        contents: read
+        pages: write
+        id-token: write
     steps:
         - name: Check out source repository
           uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,9 @@ jobs:
         - name: Merge latest FLSR files (from Freelancer folder) to clean vanilla (to freelancer_folder)
           run: fl-data-flsr -wd ${{ github.workspace }}/freelancer_folder
         - name: Sprinkle with FLSR recipes
-          run: cp Freelancer/EXE/flhook_plugins/FLSR-Crafting.cfg ${{ github.workspace }}/freelancer_folder/FLSR-Crafting.cfg
-
+          run: |
+            mkdir -r ${{ github.workspace }}/freelancer_folder/EXE/flhook_plugins/crafting
+            cp Freelancer/EXE/flhook_plugins/crafting/* ${{ github.workspace }}/freelancer_folder/EXE/flhook_plugins/crafting/
         - name: Install fl-darklint
           uses: darklab8/infra/.github/actions/install-darklint@master
         - name: Run darklint checks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,10 +31,25 @@ jobs:
           run: |
             mkdir -p ${{ github.workspace }}/freelancer_folder/EXE/flhook_plugins/crafting
             cp Freelancer/EXE/flhook_plugins/crafting/* ${{ github.workspace }}/freelancer_folder/EXE/flhook_plugins/crafting/
-        - name: Install fl-darklint
-          uses: darklab8/infra/.github/actions/install-darklint@master
-        - name: Run darklint checks
-          run: fl-darklint validate
-          env:
-            FREELANCER_FOLDER: ${{ github.workspace }}/freelancer_folder
-            FREELANCER_FOLDER_FAILBACK: ${{ github.workspace }}/Freelancer
+
+        - uses: darklab8/fl-darkstat/.github/actions/build@master
+          with:
+            site-root: "/FLSR/"
+            freelancer-folder: ${{ github.workspace }}/freelancer_folder
+            heading: <a href="https://github.com/darklab8/fl-darkstat">Darkstat</a> from <a href="https://darklab8.github.io/blog/pet_projects.html#Freelancercommunity">DarkTools</a> for <a href="https://github.com/darklab8/fl-data-flsr">FLSR</a> of <a href="https://github.com/Freelancer-Sirius-Revival/FLSR/commit/${{ github.sha }}">PREVIEW ${{ github.sha }}</a>
+            command: --stat-deals-on build
+            map-on: "true"
+            map-index-url: map.html
+            disable-dev-mode: "false"
+
+        - uses: actions/upload-pages-artifact@v3
+          with:
+            name: github-pages
+            path: ./build
+        
+        # Turn on ability to deploy to pages in repository settings, Pages tab
+        # choose "Github Actions" deployment method to Pages
+        - name: Deploy to pages
+          uses: actions/deploy-pages@v4
+          id: deployment
+          continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           run: fl-data-flsr -wd ${{ github.workspace }}/freelancer_folder
         - name: Sprinkle with FLSR recipes
           run: |
-            mkdir -r ${{ github.workspace }}/freelancer_folder/EXE/flhook_plugins/crafting
+            mkdir -p ${{ github.workspace }}/freelancer_folder/EXE/flhook_plugins/crafting
             cp Freelancer/EXE/flhook_plugins/crafting/* ${{ github.workspace }}/freelancer_folder/EXE/flhook_plugins/crafting/
         - name: Install fl-darklint
           uses: darklab8/infra/.github/actions/install-darklint@master


### PR DESCRIPTION
## Description
Now it just uses latest version of darkstat to try building all static assets for darkstat and darkmap
If CI passes, then we can be sure latest FLSR version is remaining darkstat buildable

## Optionally (not required)
If you will permit in repo settings 

> - Turn on ability to deploy to pages in repository settings, Pages tab
> - choose "Github Actions" deployment method to Pages

You will have then dev version visible on your repo Github Pages :]

