### PR TITLE
Wolfhound weapon layout update

### DIFF
--- a/Freelancer/DATA/SHIPS/shiparch.ini
+++ b/Freelancer/DATA/SHIPS/shiparch.ini
@@ -10783,7 +10783,7 @@ ids_info = 461797
 ;res html
 ; \
 ; Hull Strength: $hitpoints
-; Guns/Launchers: 3 M, 2 H, 1 X
+; Guns/Launchers: 3 M, 4 H, 1 X
 ; Turrets: -
 ; Defences: Mine, CM/Cloak
 ; Shield: H
@@ -10804,7 +10804,7 @@ ids_info2 = 460592
 ids_info3 = 461799
 ;res html
 ; $hitpoints
-; 3 M, 2 H, 1 X
+; 3 M, 4 H, 1 X
 ; -
 ; Mine, CM/Cloak
 ; H
@@ -10861,7 +10861,7 @@ HP_bay_external = HpBayDoor02
 HP_tractor_source = HpTractor_Source
 num_exhaust_nozzles = 3
 shield_link = pi_elite_shield01, HpMount, HpShield01
-hp_type = hp_gun_special_3, HpWeapon01, HpWeapon02
+hp_type = hp_gun_special_3, HpWeapon01, HpWeapon02, HpWeapon06, HpWeapon07
 hp_type = hp_gun_special_2, HpWeapon03, HpWeapon04, HpWeapon05
 hp_type = hp_fighter_shield_special_3, HpShield01
 hp_type = hp_thruster, HpThruster01


### PR DESCRIPTION
Updated the Wolfhound weapon layout from 3M 2H 1X to 3M 4H 1X after discussion and limited PVE & PVP balance testing. This also means **no** player save files need to be adjusted, as the 2 added H hardpoints are direct additions, while the remaining assignments are unchanged.

I'm also planning to update the NPC loadouts to show off the Wolfhound's 7 weapon slots in some capacity, but this isn't required to be included in the 2026.2 patch. Since I will want to at least do minimal testing on the resulting encounter ship strengths, this will come alongside faction-specific shields being added to their factions' highest-difficulty NPCs (so that those shields become lootable in gameplay), which prompts balance testing those anyway.