### PR TITLE
Always assume CAPITAL type for ships in player target frame

### DIFF
--- a/BinaryPatches/EXE/Freelancer.exe.patch
+++ b/BinaryPatches/EXE/Freelancer.exe.patch
@@ -156,6 +156,9 @@ File: EXE\Freelancer.exe
 # Enable post-cloak engine flickering effect for player trails. - BC46
 128A8D: 18	[ 1C ]
 
+# Make target view of selected SHIPS always assumed to be CAPITAL for the purpose of displaying the previous and next sub-target buttons - BC46
+0E241E: EB [ 75 ]
+
 
 ##############
 # On Base


### PR DESCRIPTION
Addresses latest FLSharp update (v0.9.2) preventing the "previous sub-target" and "next sub-target" hotkeys from working on Fighters, Freighters, Transports and other ships of non-capital type. Consequentially, also adds the clickable buttons for switching through subtargets to the target view for non-capital ships. Behaviour regarding Solars unchanged.

---

I tested this change playing on a local server as well as on the test server during balance testing, and didn't observe any unexpected side effects.